### PR TITLE
Adding Gemfile.Lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _site
 .sass-cache
 .jekyll-metadata
+Gemfile.lock


### PR DESCRIPTION
Looks like Gemfile.lock is modified every time we run the local server. I dont think it is needed in the repo at all but for now lets just ignore it