### PR TITLE
Add link to contribution guidelines

### DIFF
--- a/docs/cpp/quickstart.md
+++ b/docs/cpp/quickstart.md
@@ -173,5 +173,5 @@ Congratulations! You've created your first binary using Abseil code.
 * Read through the C++ developer guide.
 * Consult the Abseil C++ .h header files, which contain valuable reference
   information.
-* Read our contribution guidelines, if you intend to submit code to our
-  repository.
+* Read our [contribution guidelines](/community/contribute), if you intend to
+  submit code to our repository.


### PR DESCRIPTION
We should only link directly to CONTRIBUTING in one place, IMO, and that's on /community/contribute, so that's why the link goes there first.