### PR TITLE
Fix "GitHub" capitalization. Fix typo.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -27,7 +27,7 @@
             <div class="col-md-5 col-sm-5 col-xs-12 footer-community">
                 <ul class="toggle">
                     <a href="{{ site.baseurl }}/community/"><p class="right-link-headers">Community</p></a>
-                    <li><a href="https://github.com/abseil/" target="_blank"><p class="github community-links">Github</p></a></li>
+                    <li><a href="https://github.com/abseil/" target="_blank"><p class="github community-links">GitHub</p></a></li>
                     <li><a href="https://twitter.com/abseilio" target="_blank"><p class="twitter community-links">Twitter</p></a></li>
                     <li><a href="http://stackoverflow.com/tags/abseil/" target="_blank"><p class="stack-overflow community-links">Stack Overflow</p></a></li>
                 </ul>

--- a/docs/cpp/guides/synchronization.md
+++ b/docs/cpp/guides/synchronization.md
@@ -14,7 +14,7 @@ header files:
   important primitive in this library and the building block for most all
   concurrency utilities.
 * `notification.h`<br />
-  Provides a simple mechanism for notifiying threads of events.
+  Provides a simple mechanism for notifying threads of events.
 * `barrier.h` and `blocking_counter.h`<br />
   Provides synchronization abstractions for cumulative events.
 

--- a/docs/cpp/quickstart.md
+++ b/docs/cpp/quickstart.md
@@ -15,9 +15,9 @@ Running the Abseil code within this tutorial requires:
 * A compatible C++ compiler *supporting at least C++11*. Most major compilers
   are supported. 
 * [Git](https://git-scm.com/) for interacting with the Abseil source code
-  repository, which is contained on [Github](http://github.com). To install Git,
+  repository, which is contained on [GitHub](http://github.com). To install Git,
   consult the [Set Up Git](https://help.github.com/articles/set-up-git/) guide
-  on Github.
+  on GitHub.
 
 This Quickstart uses Bazel as the official build system for Abseil, which is
 supported on most major platforms (Linux, Windows, MacOS, for example) and
@@ -33,7 +33,7 @@ To download and install Bazel (and any of its dependencies), consult the
 ## Getting the Abseil Code
 
 Once you have Bazel and Git installed, you can obtain the Abseil code from its
-repository on Github:
+repository on GitHub:
 
 ```
 # Change to the directory where you want to create the code repository


### PR DESCRIPTION
Change "Github" to "GitHub".
Fix "notifiying" typo.