### PR TITLE
Totw 101: Fix the link to TotW 77

### DIFF
--- a/_posts/2017-11-02-totw-101.md
+++ b/_posts/2017-11-02-totw-101.md
@@ -45,7 +45,7 @@ generalize for most non-trivial value types.
 2.  Returning `string&` or `const string&`, initializing `string`: This is a
     copy (there must be some long-living object which we are returning a
     reference to, so once we initialize a new string there are two names for
-    that data, hence a copy. See [TotW 77])(/tips/77). Sometimes this is
+    that data, hence a copy. See [TotW 77](/tips/77)). Sometimes this is
     valuable, like if you need your `string` to outlast the lifetime guarantees
     provided by the function.
 3.  Returning `string`, initializing `string&`: This won't compile, as you


### PR DESCRIPTION
This fixes the broken link to TotW 77. The right parenthesis was not right.