### PR TITLE
Fix formatting

### DIFF
--- a/_posts/2017-12-07-totw-123.md
+++ b/_posts/2017-12-07-totw-123.md
@@ -1,5 +1,5 @@
 ---
-title: "Tip of the Week #123: `absl::optional` and `std::unique_ptr`"
+title: "Tip of the Week #123: <code>absl::optional</code> and <code>std::unique_ptr</code>"
 layout: tips
 sidenav: side-nav-tips.html
 published: true
@@ -114,12 +114,15 @@ that works. Prefer bare object, if it works for your case. Otherwise, try
 `absl::optional`. As a last resort, use `std::unique_ptr`.
 
 <table>
+  <thead>
   <tr>
-    <td></td>
-    <td>`Bar`</td>
-    <td>`absl::optional&lt;Bar&gt;`</td>
-    <td>`std::unique_ptr&lt;Bar&gt;`</td>
+    <th></th>
+    <th markdown="span">`Bar`</th>
+    <th markdown="span">`absl::optional<Bar>`</th>
+    <th markdown="span">`std::unique_ptr<Bar>`</th>
   </tr>
+  </thead>
+  <tbody>
   <tr>
     <td>Supports delayed construction</td>
     <td></td>
@@ -133,27 +136,27 @@ that works. Prefer bare object, if it works for your case. Otherwise, try
     <td></td>
   </tr>
   <tr>
-    <td>Can transfer ownership of `Bar`</td>
+    <td markdown="span">Can transfer ownership of `Bar`</td>
     <td></td>
     <td></td>
     <td>✓</td>
   </tr>
   <tr>
-    <td>Can store subclasses of `Bar`</td>
+    <td markdown="span">Can store subclasses of `Bar`</td>
     <td></td>
     <td></td>
     <td>✓</td>
   </tr>
   <tr>
     <td>Movable</td>
-    <td>If `Bar` is movable</td>
-    <td>If `Bar` is movable</td>
+    <td markdown="span">If `Bar` is movable</td>
+    <td markdown="span">If `Bar` is movable</td>
     <td>✓</td>
   </tr>
   <tr>
     <td>Copyable</td>
-    <td>If `Bar` is copyable</td>
-    <td>If `Bar` is copyable</td>
+    <td markdown="span">If `Bar` is copyable</td>
+    <td markdown="span">If `Bar` is copyable</td>
     <td></td>
   </tr>
   <tr>
@@ -170,9 +173,9 @@ that works. Prefer bare object, if it works for your case. Otherwise, try
   </tr>
   <tr>
     <td>Memory usage</td>
-    <td>`sizeof(Bar)`</td>
-    <td>`sizeof(Bar) + sizeof(bool)`[^padding]</td>
-    <td>`sizeof(Bar*)` when null, `sizeof(Bar*) + sizeof(Bar)` otherwise</td>
+    <td markdown="span">`sizeof(Bar)`</td>
+    <td markdown="span"><nobr markdown="span">`sizeof(Bar) + sizeof(bool)`</nobr>[^padding]</td>
+    <td markdown="span">`sizeof(Bar*)` when null, `sizeof(Bar*) + sizeof(Bar)` otherwise</td>
   </tr>
   <tr>
     <td>Object lifetime</td>
@@ -181,18 +184,21 @@ that works. Prefer bare object, if it works for your case. Otherwise, try
     <td>Unrestricted</td>
   </tr>
   <tr>
-    <td>Call `f(Bar*)`</td>
-    <td>`f(&val_)`</td>
-    <td>`f(&opt_.value())` or `f(&*opt_)`</td>
-    <td>`f(ptr_.get())` or `f(&*ptr_)`</td>
+    <td markdown="span">Call `f(Bar*)`</td>
+    <td markdown="span">`f(&val_)`</td>
+    <td markdown="span">`f(&opt_.value())` or `f(&*opt_)`</td>
+    <td markdown="span">`f(ptr_.get())` or `f(&*ptr_)`</td>
   </tr>
   <tr>
     <td>Remove value</td>
     <td>N/A</td>
-    <td>`opt_.reset();` or `opt_ = absl::nullopt;`</td>
-    <td>`ptr_.reset();` or `ptr_ = nullptr;`</td>
+    <td markdown="span">`opt_.reset();` or `opt_ = absl::nullopt;`</td>
+    <td markdown="span">`ptr_.reset();` or `ptr_ = nullptr;`</td>
   </tr>
+  </tbody>
 </table>
+
 [^deleter]: In case of a non-empty custom deleter there is also an additional
     space for that deleter.
+
 [^padding]: Also padding may be added.


### PR DESCRIPTION
HTML table doesn't support embedded `` without repeating markdown="span"
on every line.

Without <nobr> "2" of [^padding] gets right on top of +