### PR TITLE
Add Tips on StrCat, StrSplit, StrJoin (3, 10, 36, 59)

### DIFF
--- a/_posts/2018-01-25-totw-10.md
+++ b/_posts/2018-01-25-totw-10.md
@@ -1,0 +1,77 @@
+---
+title: "Tip of the Week #10: Splitting Strings, not Hairs"
+layout: tips
+sidenav: side-nav-tips.html
+published: false
+permalink: tips/10
+type: markdown
+order: "010"
+---
+
+Originally published as totw/10 on 2012-08-16
+
+*By Greg Miller [(jgm@google.com)](mailto:jgm@google.com)*
+
+Updated 2018-01-24
+
+*I tend to have an odd split in my mind. --John Cleese*
+
+Splitting a string into substrings is a common task in any general-purpose
+programming language, and C++ is no exception. When the need arose at Google,
+many engineers found themselves wading through a morass of splitting functions
+in organically grown header files. You’d have hunted for the magical combination
+of input parameters, output parameters, and semantics that satisfies your need.
+After studying 50+ functions in a 600+ line header, you may have finally decided
+on something as tortuously named as
+`SplitStringViewToDequeOfStringAllowEmpty()`.
+
+To address this, the C++ Library Team implemented a new API for splitting
+strings, available for use in
+[absl/strings/str_split.h][str_split]
+
+The new API replaced many of the pandora’s box of splitting functions with a
+single `absl::StrSplit()` function. This function takes an input string to be
+split and a delimiter on which to split the string as arguments.
+`absl::StrSplit()` adapts the returned collection to the type specified by the
+caller. `absl::StrSplit()`’s implementation is efficient because
+`absl::string_view`s are used internally; no copies are made unless the caller
+explicitly requests to store the results in a collection of string objects
+(which copy their data).
+
+Enough talk, let’s see some examples:
+
+```
+// Splits on commas. Stores in vector of string_view (no copies).
+std::vector<absl::string_view> v = absl::StrSplit("a,b,c", ',');
+
+// Splits on commas. Stores in vector of string (data copied once).
+std::vector<string> v = absl::StrSplit("a,b,c", ',');
+
+// Splits on literal string "=>" (not either of "=" or ">")
+std::vector<absl::string_view> v = absl::StrSplit("a=>b=>c", "=>");
+
+// Splits on any of the given characters (',' or ';')
+using absl::ByAnyChar;
+std::vector<string> v = strings::StrSplit("a,b;c", ByAnyChar(",;"));
+
+// Stores in various containers (also works w/ absl::string_view)
+std::set<string> s = absl::StrSplit("a,b,c", ',');
+std::multiset<string> s = absl::StrSplit("a,b,c", ',');
+std::list<string> li = absl::StrSplit("a,b,c", ',');
+
+// Equiv. to the mythical SplitStringViewToDequeOfStringAllowEmpty()
+std::deque<string> d = absl::StrSplit("a,b,c", ',');
+
+// Yields "a"->"1", "b"->"2", "c"->"3"
+std::map<string, string> m = absl::StrSplit("a,1,b,2,c,3", ',');
+```
+
+For more information, take a look at
+[absl/strings/str_split.h][str_split] for details about how to use
+the Split API and [absl/strings/str_split_test.cc][str_split_test]
+for some more examples.
+
+Thanks for reading. Now I really gotta split...
+
+[str_split]: https://github.com/abseil/abseil-cpp/blob/master/absl/strings/str_split.h
+[str_split_test]: https://github.com/abseil/abseil-cpp/blob/master/absl/strings/str_split_test.cc

--- a/_posts/2018-01-25-totw-10.md
+++ b/_posts/2018-01-25-totw-10.md
@@ -2,7 +2,7 @@
 title: "Tip of the Week #10: Splitting Strings, not Hairs"
 layout: tips
 sidenav: side-nav-tips.html
-published: false
+published: true
 permalink: tips/10
 type: markdown
 order: "010"

--- a/_posts/2018-01-25-totw-10.md
+++ b/_posts/2018-01-25-totw-10.md
@@ -29,7 +29,7 @@ To address this, the C++ Library Team implemented a new API for splitting
 strings, available for use in
 [absl/strings/str_split.h][str_split]
 
-The new API replaced many of the pandora’s box of splitting functions with a
+The new API replaced many of these splitting functions with a
 single `absl::StrSplit()` function. This function takes an input string to be
 split and a delimiter on which to split the string as arguments.
 `absl::StrSplit()` adapts the returned collection to the type specified by the
@@ -45,25 +45,25 @@ Enough talk, let’s see some examples:
 std::vector<absl::string_view> v = absl::StrSplit("a,b,c", ',');
 
 // Splits on commas. Stores in vector of string (data copied once).
-std::vector<string> v = absl::StrSplit("a,b,c", ',');
+std::vector<std::string> v = absl::StrSplit("a,b,c", ',');
 
 // Splits on literal string "=>" (not either of "=" or ">")
 std::vector<absl::string_view> v = absl::StrSplit("a=>b=>c", "=>");
 
 // Splits on any of the given characters (',' or ';')
 using absl::ByAnyChar;
-std::vector<string> v = strings::StrSplit("a,b;c", ByAnyChar(",;"));
+std::vector<std::string> v = absl::StrSplit("a,b;c", ByAnyChar(",;"));
 
 // Stores in various containers (also works w/ absl::string_view)
-std::set<string> s = absl::StrSplit("a,b,c", ',');
-std::multiset<string> s = absl::StrSplit("a,b,c", ',');
-std::list<string> li = absl::StrSplit("a,b,c", ',');
+std::set<std::string> s = absl::StrSplit("a,b,c", ',');
+std::multiset<std::string> s = absl::StrSplit("a,b,c", ',');
+std::list<std::string> li = absl::StrSplit("a,b,c", ',');
 
 // Equiv. to the mythical SplitStringViewToDequeOfStringAllowEmpty()
-std::deque<string> d = absl::StrSplit("a,b,c", ',');
+std::deque<std::string> d = absl::StrSplit("a,b,c", ',');
 
 // Yields "a"->"1", "b"->"2", "c"->"3"
-std::map<string, string> m = absl::StrSplit("a,1,b,2,c,3", ',');
+std::map<std::string, std::string> m = absl::StrSplit("a,1,b,2,c,3", ',');
 ```
 
 For more information, take a look at

--- a/_posts/2018-01-25-totw-3.md
+++ b/_posts/2018-01-25-totw-3.md
@@ -91,27 +91,4 @@ just string types: you can use `absl::StrCat`/`absl::StrAppend` to convert
 string foo = absl::StrCat("The year is ", year);
 ```
 
-```cpp
-printf("%s\n", sv.data()); // DON’T DO THIS
-```
-
-However, the following is fine:
-
-```cpp
-printf("%.*s\n", static_cast<int>(sv.size()), sv.data());
-```
-
-*  You can output a `string_view` just like you would a string or a
-  `const char*`:
-
-```cpp
-std::cout << "Took '" << s << "'";
-```
-
-* You can convert an existing routine that accepts `const string&` or
-  NUL-terminated `const char*` to `string_view` safely in most cases. The only
-  danger we have encountered in performing this operation is if the address of
-  the function has been taken, this will result in a build break as the
-  resulting function-pointer type will be different.
-
 [str_cat]: https://github.com/abseil/abseil-cpp/blob/master/absl/strings/str_cat.h

--- a/_posts/2018-01-25-totw-3.md
+++ b/_posts/2018-01-25-totw-3.md
@@ -57,8 +57,8 @@ string foobar = std::move(temp) + baz;
 
 Specifically, note that the contents of `foo` and `bar` must be copied to a
 temporary location before they are placed within `foobar`. (For more on
-`std::move`, see [Tip of the Week #77: Temporaries, moves, and copies]
-(tips/77).)
+`std::move`, see
+[Tip of the Week #77: Temporaries, moves, and copies](/tips/77).)
 
 C++11 at least allows the second concatenation to happen without creating a new
 string object: `std::move(temp) + baz` is equivalent to

--- a/_posts/2018-01-25-totw-3.md
+++ b/_posts/2018-01-25-totw-3.md
@@ -1,0 +1,117 @@
+---
+title: "Tip of the Week #3: String Concatenation and operator+ vs. StrCat()"
+layout: tips
+sidenav: side-nav-tips.html
+published: false
+permalink: tips/3
+type: markdown
+order: "003"
+---
+
+Originally published as totw/3 on 2012-05-11
+
+Updated 2017-09-18; revised 2018-01-22
+
+Users are often surprised when a reviewer says, "Don't use the string
+concatenation operator, it's not that efficient." How can it be that
+`string::operator+` is inefficient? Isn't it hard to get that wrong?
+
+It turns out, such inefficiency isn’t clear cut. These two snippets have
+close to the same execution time, in practice:
+
+```cpp
+string foo = LongString1();
+string bar = LongString2();
+string foobar = foo + bar;
+
+string foo = LongString1();
+string bar = LongString2();
+string foobar = absl::StrCat(foo, bar);
+```
+
+However, the same is not true for these two snippets:
+
+```cpp
+string foo = LongString1();
+string bar = LongString2();
+string baz = LongString3();
+string foobar = foo + bar + baz;
+
+string foo = LongString1();
+string bar = LongString2();
+string baz = LongString3();
+string foobar = absl::StrCat(foo, bar, baz);
+```
+
+The reason these two cases differ can be understood when we pick apart what is
+happening in the expression `foo + bar + baz`. Since there are no overloads for
+three-argument operators in C++, this operation is necessarily going to make two
+calls to `string::operator+`. And between those two calls, the operation will
+construct (and store) a temporary string. So `string foobar = foo + bar + baz`
+is really equivalent to:
+
+```cpp
+string temp = foo + bar;
+string foobar = std::move(temp) + baz;
+```
+
+Specifically, note that the contents of `foo` and `bar` must be copied to a
+temporary location before they are placed within `foobar`. (For more on
+`std::move`, see [Tip of the Week #77: Temporaries, moves, and copies]
+(tips/77).)
+
+C++11 at least allows the second concatenation to happen without creating a new
+string object: `std::move(temp) + baz` is equivalent to
+`std::move(temp.append(baz))`. However, it's possible that the buffer initially
+allocated for the temporary won't be large enough to hold the final string, in
+which case a reallocation (and another copy) will be required. As a result, in
+the worst case, chains of `n` string concatenations require O(n) reallocations.
+
+It is better instead to use `absl::StrCat()`, a nice helper function from
+[absl/strings/str_cat.h][str_cat] that calculates the necessary string
+length, reserves that size, and concatenates all of the input data into the
+output - a well-optimized O(n). Similarly, for cases like:
+
+```cpp
+foobar += foo + bar + baz;
+```
+
+use `absl::StrAppend()`, which performs similar optimizations:
+
+```cpp
+absl::StrAppend(&foobar, foo, bar, baz);
+```
+
+As well, `absl::StrCat()` and `absl::StrAppend()` operate on types other than
+just string types: you can use `absl::StrCat`/`absl::StrAppend` to convert
+`int32`, `uint32`, `int64`, `uint64`, `float`, `double`, `const char*`, and
+`string_view`, like this:
+
+```cpp
+string foo = absl::StrCat("The year is ", year);
+```
+
+```cpp
+printf("%s\n", sv.data()); // DON’T DO THIS
+```
+
+However, the following is fine:
+
+```cpp
+printf("%.*s\n", static_cast<int>(sv.size()), sv.data());
+```
+
+*  You can output a `string_view` just like you would a string or a
+  `const char*`:
+
+```cpp
+std::cout << "Took '" << s << "'";
+```
+
+* You can convert an existing routine that accepts `const string&` or
+  NUL-terminated `const char*` to `string_view` safely in most cases. The only
+  danger we have encountered in performing this operation is if the address of
+  the function has been taken, this will result in a build break as the
+  resulting function-pointer type will be different.
+
+[str_cat]: https://github.com/abseil/abseil-cpp/blob/master/absl/strings/str_cat.h

--- a/_posts/2018-01-25-totw-3.md
+++ b/_posts/2018-01-25-totw-3.md
@@ -14,45 +14,45 @@ Updated 2017-09-18; revised 2018-01-22
 
 Users are often surprised when a reviewer says, "Don't use the string
 concatenation operator, it's not that efficient." How can it be that
-`string::operator+` is inefficient? Isn't it hard to get that wrong?
+`std::string::operator+` is inefficient? Isn't it hard to get that wrong?
 
 It turns out, such inefficiency isn’t clear cut. These two snippets have
 close to the same execution time, in practice:
 
 ```cpp
-string foo = LongString1();
-string bar = LongString2();
-string foobar = foo + bar;
+std::string foo = LongString1();
+std::string bar = LongString2();
+std::string foobar = foo + bar;
 
-string foo = LongString1();
-string bar = LongString2();
-string foobar = absl::StrCat(foo, bar);
+std::string foo = LongString1();
+std::string bar = LongString2();
+std::string foobar = absl::StrCat(foo, bar);
 ```
 
 However, the same is not true for these two snippets:
 
 ```cpp
-string foo = LongString1();
-string bar = LongString2();
-string baz = LongString3();
+std::string foo = LongString1();
+std::string bar = LongString2();
+std::string baz = LongString3();
 string foobar = foo + bar + baz;
 
-string foo = LongString1();
-string bar = LongString2();
-string baz = LongString3();
-string foobar = absl::StrCat(foo, bar, baz);
+std::string foo = LongString1();
+std::string bar = LongString2();
+std::string baz = LongString3();
+std::string foobar = absl::StrCat(foo, bar, baz);
 ```
 
 The reason these two cases differ can be understood when we pick apart what is
 happening in the expression `foo + bar + baz`. Since there are no overloads for
 three-argument operators in C++, this operation is necessarily going to make two
 calls to `string::operator+`. And between those two calls, the operation will
-construct (and store) a temporary string. So `string foobar = foo + bar + baz`
-is really equivalent to:
+construct (and store) a temporary string. So
+`std::string foobar = foo + bar + baz` is really equivalent to:
 
 ```cpp
-string temp = foo + bar;
-string foobar = std::move(temp) + baz;
+std::string temp = foo + bar;
+std::string foobar = std::move(temp) + baz;
 ```
 
 Specifically, note that the contents of `foo` and `bar` must be copied to a
@@ -65,12 +65,12 @@ string object: `std::move(temp) + baz` is equivalent to
 `std::move(temp.append(baz))`. However, it's possible that the buffer initially
 allocated for the temporary won't be large enough to hold the final string, in
 which case a reallocation (and another copy) will be required. As a result, in
-the worst case, chains of `n` string concatenations require O(n) reallocations.
+the worst case, chains of `n` string concatenations require `O(n)` reallocations.
 
 It is better instead to use `absl::StrCat()`, a nice helper function from
 [absl/strings/str_cat.h][str_cat] that calculates the necessary string
 length, reserves that size, and concatenates all of the input data into the
-output - a well-optimized O(n). Similarly, for cases like:
+output - a well-optimized `O(n)`. Similarly, for cases like:
 
 ```cpp
 foobar += foo + bar + baz;
@@ -84,11 +84,11 @@ absl::StrAppend(&foobar, foo, bar, baz);
 
 As well, `absl::StrCat()` and `absl::StrAppend()` operate on types other than
 just string types: you can use `absl::StrCat`/`absl::StrAppend` to convert
-`int32`, `uint32`, `int64`, `uint64`, `float`, `double`, `const char*`, and
+`int32_t`, `uint32_t`, `int64_t`, `uint64_t`, `float`, `double`, `const char*`, and
 `string_view`, like this:
 
 ```cpp
-string foo = absl::StrCat("The year is ", year);
+std::string foo = absl::StrCat("The year is ", year);
 ```
 
 [str_cat]: https://github.com/abseil/abseil-cpp/blob/master/absl/strings/str_cat.h

--- a/_posts/2018-01-25-totw-3.md
+++ b/_posts/2018-01-25-totw-3.md
@@ -2,7 +2,7 @@
 title: "Tip of the Week #3: String Concatenation and operator+ vs. StrCat()"
 layout: tips
 sidenav: side-nav-tips.html
-published: false
+published: true
 permalink: tips/3
 type: markdown
 order: "003"

--- a/_posts/2018-01-25-totw-36.md
+++ b/_posts/2018-01-25-totw-36.md
@@ -2,7 +2,7 @@
 title: "Tip of the Week #36: New Join API"
 layout: tips
 sidenav: side-nav-tips.html
-published: false
+published: true
 permalink: tips/36
 type: markdown
 order: "036"

--- a/_posts/2018-01-25-totw-36.md
+++ b/_posts/2018-01-25-totw-36.md
@@ -1,0 +1,70 @@
+---
+title: "Tip of the Week #36: New Join API"
+layout: tips
+sidenav: side-nav-tips.html
+published: false
+permalink: tips/36
+type: markdown
+order: "036"
+---
+
+Originally published as totw/36 on 2013-03-21
+
+*By Greg Miller [(jgm@google.com)](mailto:jgm@google.com)*
+
+Updated 2018-01-24
+
+*"I got a good mind to join a club and beat you over the head with it." --
+Groucho Marx*
+
+Many of you asked for a new joining API and we heard you. We now have one
+joining function to replace them all, and it is spelled `absl::StrJoin()`.
+You simply give it a collection of objects to be joined and a separator
+ string, and it does the rest. It will work with collections of `string`,
+`absl::string_view`, `int`, `double` -- any type that `absl::StrCat()`
+supports. If you need to join a type that will not `StrCat()`, you can
+also provide a custom `Formatter` for that type; we'll see below how the
+use of a `Formatter` will let us nicely join a map.
+
+Now for some quick examples:
+
+```cpp
+std::vector<string> v = {"a", "b", "c"};
+string s = absl::StrJoin(v, "-");
+// s == "a-b-c"
+
+std::vector<absl::string_view> v = {"a", "b", "c"};
+string s = absl::StrJoin(v.begin(), v.end(), "-");
+// s == "a-b-c"
+
+std::vector<int> v = {1, 2, 3};
+string s = absl::StrJoin(v, "-");
+// s == "1-2-3"
+
+const int a[] = {1, 2, 3};
+string s = absl::StrJoin(a, "-");
+// s == "1-2-3"
+```
+
+The following example passes a `Formatter` argument to format the pairs in a
+map, using a different separator. This makes the output nice and readable.
+
+```cpp
+std::map<string, int> m = {{"a", 1}, {"b", 2}, {"c", 3}};
+string s = absl::StrJoin(m, ";", absl::PairFormatter("="));
+// s == "a=1;b=2;c=3"
+```
+
+You can also pass a C++ lambda expression as a `Formatter`.
+
+```cpp
+std::vector<Foo> foos = GetFoos();
+
+string s = absl::StrJoin(foos, ", ", [](string* out, const Foo& foo) {
+  absl::StrAppend(out, foo.ToString());
+});
+```
+
+Please refer to [absl/strings/str_join.h][str_join] for more details.
+
+[str_join]: https://github.com/abseil/abseil-cpp/blob/master/absl/strings/str_join.h

--- a/_posts/2018-01-25-totw-36.md
+++ b/_posts/2018-01-25-totw-36.md
@@ -20,7 +20,7 @@ Groucho Marx*
 Many of you asked for a new joining API and we heard you. We now have one
 joining function to replace them all, and it is spelled `absl::StrJoin()`.
 You simply give it a collection of objects to be joined and a separator
- string, and it does the rest. It will work with collections of `string`,
+ string, and it does the rest. It will work with collections of `std::string`,
 `absl::string_view`, `int`, `double` -- any type that `absl::StrCat()`
 supports. If you need to join a type that will not `StrCat()`, you can
 also provide a custom `Formatter` for that type; we'll see below how the
@@ -29,20 +29,20 @@ use of a `Formatter` will let us nicely join a map.
 Now for some quick examples:
 
 ```c++
-std::vector<string> v = {"a", "b", "c"};
-string s = absl::StrJoin(v, "-");
+std::vector<std::string> v = {"a", "b", "c"};
+std::string s = absl::StrJoin(v, "-");
 // s == "a-b-c"
 
 std::vector<absl::string_view> v = {"a", "b", "c"};
-string s = absl::StrJoin(v.begin(), v.end(), "-");
+std::string s = absl::StrJoin(v.begin(), v.end(), "-");
 // s == "a-b-c"
 
 std::vector<int> v = {1, 2, 3};
-string s = absl::StrJoin(v, "-");
+std::string s = absl::StrJoin(v, "-");
 // s == "1-2-3"
 
 const int a[] = {1, 2, 3};
-string s = absl::StrJoin(a, "-");
+std::string s = absl::StrJoin(a, "-");
 // s == "1-2-3"
 ```
 
@@ -51,8 +51,8 @@ map, using a different separator. This makes the output nice and readable.
 
 {% raw %}
 ```cpp
-std::map<string, int> m = {{"a", 1}, {"b", 2}, {"c", 3}};
-string s = absl::StrJoin(m, ";", absl::PairFormatter("="));
+std::map<std::string, int> m = {{"a", 1}, {"b", 2}, {"c", 3}};
+std::string s = absl::StrJoin(m, ";", absl::PairFormatter("="));
 // s == "a=1;b=2;c=3"
 ```
 {% endraw %}
@@ -62,7 +62,7 @@ You can also pass a C++ lambda expression as a `Formatter`.
 ```cpp
 std::vector<Foo> foos = GetFoos();
 
-string s = absl::StrJoin(foos, ", ", [](string* out, const Foo& foo) {
+std::string s = absl::StrJoin(foos, ", ", [](std::string* out, const Foo& foo) {
   absl::StrAppend(out, foo.ToString());
 });
 ```

--- a/_posts/2018-01-25-totw-36.md
+++ b/_posts/2018-01-25-totw-36.md
@@ -28,7 +28,7 @@ use of a `Formatter` will let us nicely join a map.
 
 Now for some quick examples:
 
-```cpp
+```c++
 std::vector<string> v = {"a", "b", "c"};
 string s = absl::StrJoin(v, "-");
 // s == "a-b-c"
@@ -49,11 +49,13 @@ string s = absl::StrJoin(a, "-");
 The following example passes a `Formatter` argument to format the pairs in a
 map, using a different separator. This makes the output nice and readable.
 
+{% raw %}
 ```cpp
 std::map<string, int> m = {{"a", 1}, {"b", 2}, {"c", 3}};
 string s = absl::StrJoin(m, ";", absl::PairFormatter("="));
 // s == "a=1;b=2;c=3"
 ```
+{% endraw %}
 
 You can also pass a C++ lambda expression as a `Formatter`.
 

--- a/_posts/2018-01-25-totw-59.md
+++ b/_posts/2018-01-25-totw-59.md
@@ -2,7 +2,7 @@
 title: "Tip of the Week #59: Joining Tuples"
 layout: tips
 sidenav: side-nav-tips.html
-published: false
+published: true
 permalink: tips/59
 type: markdown
 order: "059"

--- a/_posts/2018-01-25-totw-59.md
+++ b/_posts/2018-01-25-totw-59.md
@@ -1,0 +1,81 @@
+---
+title: "Tip of the Week #59: Joining Tuples"
+layout: tips
+sidenav: side-nav-tips.html
+published: false
+permalink: tips/59
+type: markdown
+order: "059"
+---
+
+Originally published as totw/59 on 2013-10-21
+
+*By Greg Miller [(jgm@google.com)](mailto:jgm@google.com)*
+
+Updated 2018-01-24
+
+*"Now join your hands, and with your hands your hearts." --Henry VI, William
+Shakespeare*
+
+In March, 2013 we announced the new [string joining
+API][str_join] in [Tip #36](tips/36). The response to the new API was quite
+positive, and we worked to make the API even better. Topping the list of
+feature requests was the ability to join arbitrary lists of possibly
+heterogeneous data (I can only assume that Shakespeare was referring to
+joining a heterogeneous collection of hands and hearts). We didn't go with
+the varargs or variadic template route, but we did add support for joining
+`std::tuple` objects, which addresses this need quite nicely. Simply create
+a `std::tuple` containing your heterogeneous data, and `absl::StrJoin()`
+will accept it just like any other container. Here are a few examples:
+
+```cpp
+auto tup = std::make_tuple(123, "abc", 0.456);
+string s = absl::StrJoin(tup, "-");
+s = absl::StrJoin(std::make_tuple(123, "abc", 0.456), "-");
+
+int a = 123;
+string b = "abc";
+double c = 0.456;
+
+// Works, but copies all arguments.
+s = absl::StrJoin(std::make_tuple(a, b, c), "-");
+// No copies, but only works with lvalues.
+s = absl::StrJoin(std::tie(a, b, c), "-");
+// No copies, and works with lvalues and rvalues.
+s = absl::StrJoin(std::forward_as_tuple(123, MakeFoo(), c), "-");
+```
+
+As with joining any container, the elements of the tuple are formatted using an
+`absl::AlphaNumFormatter` by default, but you can specify a custom
+[join Formatter][join_formatter] if your tuple contains elements that are not
+handled by the default formatter. To format a tuple with multiple custom
+element types, your custom `Formatter` object may contain multiple overloads
+of `operator()`.
+
+For example:
+
+```cpp
+struct Foo {};
+struct Bar {};
+
+struct MyFormatter {
+  void operator()(string* out, const Foo& f) const {
+    out->append("Foo");
+  }
+  void operator()(string* out, const Bar& b) const {
+    out->append("Bar");
+  }
+};
+
+string s = absl::StrJoin(std::forward_as_tuple(Foo(), Bar()), "-",
+                         MyFormatter());
+EXPECT_EQ(s, "Foo-Bar");
+```
+
+The goal of the `absl::StrJoin()` API is to join any collection, range, list, or
+group of data using an intuitive and consistent syntax. We think joining
+`std::tuple` objects fits nicely with this goal and adds more flexibility to the
+API.
+
+[str_join]: https://github.com/abseil/abseil-cpp/blob/master/absl/strings/str_join.h
+[join_formatter]: https://github.com/abseil/abseil-cpp/blob/master/absl/strings/str_join.h#L64

--- a/_posts/2018-01-25-totw-59.md
+++ b/_posts/2018-01-25-totw-59.md
@@ -18,7 +18,7 @@ Updated 2018-01-24
 Shakespeare*
 
 In March, 2013 we announced the new [string joining
-API][str_join] in [Tip #36](tips/36). The response to the new API was quite
+API][str_join] in [Tip #36](/tips/36). The response to the new API was quite
 positive, and we worked to make the API even better. Topping the list of
 feature requests was the ability to join arbitrary lists of possibly
 heterogeneous data (I can only assume that Shakespeare was referring to

--- a/_posts/2018-01-25-totw-59.md
+++ b/_posts/2018-01-25-totw-59.md
@@ -30,11 +30,11 @@ will accept it just like any other container. Here are a few examples:
 
 ```cpp
 auto tup = std::make_tuple(123, "abc", 0.456);
-string s = absl::StrJoin(tup, "-");
+std::string s = absl::StrJoin(tup, "-");
 s = absl::StrJoin(std::make_tuple(123, "abc", 0.456), "-");
 
 int a = 123;
-string b = "abc";
+std::string b = "abc";
 double c = 0.456;
 
 // Works, but copies all arguments.
@@ -67,7 +67,7 @@ struct MyFormatter {
   }
 };
 
-string s = absl::StrJoin(std::forward_as_tuple(Foo(), Bar()), "-",
+std::string s = absl::StrJoin(std::forward_as_tuple(Foo(), Bar()), "-",
                          MyFormatter());
 EXPECT_EQ(s, "Foo-Bar");
 ```


### PR DESCRIPTION
These have already been reviewed by c-library-team for publication. Some have been changed to remove internal-only information.