### PR TITLE
Tip fixes. Add semicolon, remove parens to avoid Liquid error.

### DIFF
--- a/_posts/2017-12-21-totw-42.md
+++ b/_posts/2017-12-21-totw-42.md
@@ -66,7 +66,7 @@ class Foo {
 
  private:
   // Clients can't invoke the constructor directly.
-  Foo()
+  Foo();
 };
 
 // foo.c

--- a/tips/index.md
+++ b/tips/index.md
@@ -42,7 +42,7 @@ exceptions that are historical, where applicable.
 below in the order of re-publication.**
 
 <ul>
-  {% assign sorted_posts = (site.posts | sort: 'date' | reverse) %}
+  {% assign sorted_posts = site.posts | sort: 'date' | reverse %}
   {% assign datelist = '' %}
   {% assign new = true %}
 


### PR DESCRIPTION
The second isn't really an error, though it is a warning in Liquid:

Liquid Warning: Liquid syntax error (line 38): Expected dotdot but found pipe in "{{(site.posts | sort: 'date' | reverse) }}" in tips/index.md
