### PR TITLE
Remove errant -b flag from git clone command in Quickstart

### DIFF
--- a/docs/cpp/quickstart.md
+++ b/docs/cpp/quickstart.md
@@ -41,7 +41,7 @@ repository on GitHub:
 # Change to the directory where you want to create the code repository
 $ cd ~
 $ mkdir Source; cd Source
-$ git clone -b  https://github.com/abseil/abseil-cpp.git
+$ git clone -b master https://github.com/abseil/abseil-cpp.git
 Cloning into 'abseil-cpp'...
 remote: Total 1935 (delta 1083), reused 1935 (delta 1083)
 Receiving objects: 100% (1935/1935), 1.06 MiB | 0 bytes/s, done.

--- a/docs/cpp/quickstart.md
+++ b/docs/cpp/quickstart.md
@@ -41,7 +41,7 @@ repository on GitHub:
 # Change to the directory where you want to create the code repository
 $ cd ~
 $ mkdir Source; cd Source
-$ git clone -b master https://github.com/abseil/abseil-cpp.git
+$ git clone https://github.com/abseil/abseil-cpp.git
 Cloning into 'abseil-cpp'...
 remote: Total 1935 (delta 1083), reused 1935 (delta 1083)
 Receiving objects: 100% (1935/1935), 1.06 MiB | 0 bytes/s, done.


### PR DESCRIPTION
This PR removes a `-b` flag (without branch specified) from the `git clone` command in the quickstart documentation.

~I could also remove the `-b` flag if this is preferred.~