### PR TITLE
Update top nav bar to promote C++ devguide

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -17,11 +17,11 @@
 
         <ul class="nav col-xs-10">
           {% assign current = page.url | downcase | split: '/' %}
-          <li><a href="{{ site.baseurl }}/about" {% if current[1] == 'about' %}class='current'{% endif %}>About</a></li>
-          <li><a href="{{ site.baseurl }}/docs/" {% if current[1] == 'docs' %}class='current'{% endif %}>Docs</a></li>
+          <li><a href="{{ site.baseurl }}/about/" {% if current[1] == 'about' %}class='current'{% endif %}>About</a></li>
+          <li><a href="{{ site.baseurl }}/docs/cpp/" {% if current[1] == 'cpp' %}class='current'{% endif %}>C++ Guide</a></li>
           <li><a href="{{ site.baseurl }}/tips/" {% if current[1] == 'tips' %}class='current'{% endif %}>C++ Tips</a></li>
 		  <li><a href="{{ site.baseurl }}/blog/" {% if current[1] == 'blog' %}class='current'{% endif %}>Blog</a></li>
-          <li><a href="{{ site.baseurl }}/community" {% if current[1] == 'community.html' %}class='current'{% endif %}>Community</a></li>
+          <li><a href="{{ site.baseurl }}/community/" {% if current[1] == 'community.html' %}class='current'{% endif %}>Community</a></li>
         </ul>
 
       </div>

--- a/_includes/side-nav-cpp.html
+++ b/_includes/side-nav-cpp.html
@@ -4,7 +4,7 @@
 	<li><h5 class="doc-side-nav-title">
 	<a href="{{ site.baseurl }}/docs/cpp.html" {% if (current[2] == 'cpp' && current[3] == "") %}class='current'{% endif %}><b>C++ Devguide</b></a></h5></li>
 	<li class="doc-side-nav-list-item">
-	  <a href="{{ site.baseurl }}/docs/cpp/quickstart" {% if current[3] == 'quickstart.html' %}class='current'{% endif %}>
+	  <a href="{{ site.baseurl }}/docs/cpp/quickstart.html" {% if current[3] == 'quickstart.html' %}class='current'{% endif %}>
 	  Quickstart</a></li>
 	  
 	<li><h6 class="doc-side-nav-title">

--- a/docs/cpp.md
+++ b/docs/cpp.md
@@ -16,6 +16,6 @@ to augment those code comments. For full reference documentation, consult
 the header files directly.
 
 
-* [C++ Quickstart](cpp/quickstart)
-* [C++ Programming Guides](cpp/guides/)
-* [C++ Platforms Guide](cpp/platforms/)
+* [C++ Quickstart](quickstart.html)
+* [C++ Programming Guides](guides/)
+* [C++ Platforms Guide](platforms/)


### PR DESCRIPTION
Changing "Docs" to "C++ Guide" as this is the only guide currently. This will reduce required click-throughs to get to the C++ guide to 1 rather than the current 2.