### PR TITLE
Update Bazel local_repository doc

### DIFF
--- a/docs/cpp/quickstart.md
+++ b/docs/cpp/quickstart.md
@@ -90,8 +90,7 @@ local_repository(
   # WORKSPACE file, in its `workspace()` metadata
   name = "com_google_absl",
 
-  # NOTE: Bazel paths must be absolute paths. E.g., you can't use ~/Source
-  path = "/PATH_TO_SOURCE/Source/abseil-cpp",
+  path = "abseil-cpp",
 )
 ```
 


### PR DESCRIPTION
The sample code says that Bazel local_repository paths must be absolute. That's not actually true; you can use a relative path. See https://github.com/davidstanke/abseil-demo/blob/master/WORKSPACE#L3 for an example that works just fine for me.