### PR TITLE
Update contrast for body text

### DIFF
--- a/_sass/base/_colors.scss
+++ b/_sass/base/_colors.scss
@@ -23,7 +23,7 @@ $linkColorTertiary: $gray;
 $codeColor: darken($linkColor, 20%);
 $codeBkColor: #ebfaf8;
 $wellColor: #F9F9F9;
-$textColor: #535f61;
+$textColor: #424B4D;  // Aim to get WCAG to ~9.0
 $titleColor: #555555;
 $noteColor: #E1F5FE;
 $headingsColor: rgb(21, 91, 103);

--- a/docs/cpp/quickstart.md
+++ b/docs/cpp/quickstart.md
@@ -5,6 +5,12 @@ sidenav: side-nav-cpp.html
 type: markdown
 ---
 
+## C++ Quickstart
+
+This document is designed to allow you to get the Abseil development
+environment up and running. We recommend that each person starting
+development with Abseil code at least run through this quick tutorial.
+
 ## Prerequisites
 
 Running the Abseil code within this tutorial requires:


### PR DESCRIPTION
Although this diverges with other OSS websites, I think we should at least achieve minimum of WCAG AAA 7.0 for body text. (Current text contast is 6.6.) I've upped contrast to 9.0, based on abseil.io body text being slightly smaller than normal.