### PR TITLE
Export of internal doc changes to Abseil OSS

### DIFF
--- a/about/design/dropin-types.md
+++ b/about/design/dropin-types.md
@@ -1,12 +1,15 @@
 ---
-title: Abseil and Pre-adopted `std::` types
+title: Abseil and Pre-adopted `std::` Types
 layout: about
 sidenav: side-nav-design.html
 type: markdown
 ---
 
+## Pre-adopted `std::` Types
+
 Abseil’s initial release includes several types that mimic the API of C++17
-vocabulary types: `absl::string_view`, `absl::any`, and `absl::optional`.
+vocabulary types. For example, `absl::string_view`, `absl::any`, and
+`absl::optional` are all C++11 versions of C++17 types.
 
 Like everything else currently in Abseil, these types only require C++11.
 Where there are API designs that require C++14 or C++17, we’ve tried to ensure

--- a/docs/cpp/guides/index.md
+++ b/docs/cpp/guides/index.md
@@ -12,5 +12,7 @@ Over time, we hope to have comprehensive documentation, including examples, for
 all code within Abseil within this guide.
 
 * [Abseil Fundamentals](base)
+* [Meta Library Guide](meta)
+* [Numeric Library Guide](numeric)
 * [Synchronization Guide](synchronization)
 * [Strings Guide](strings)

--- a/docs/cpp/guides/meta.md
+++ b/docs/cpp/guides/meta.md
@@ -1,0 +1,84 @@
+---
+title: The Meta Library
+layout: docs
+sidenav: side-nav-cpp.html
+type: markdown
+---
+
+## The Meta Library
+
+This `meta` library contains C++11-compatible versions of standard
+`<type_traits>` API functions for determining the characteristics of types. Such
+traits can support type inference, classification, and transformation, as well
+as make it easier to write templates based on generic type behavior.
+
+See http://en.cppreference.com/w/cpp/header/type_traits
+
+>WARNING: use of many of the constructs in this header will count as "complex
+>template metaprogramming", so before proceeding, please carefully consider
+>https://google.github.io/styleguide/cppguide.html#Template_metaprogramming
+>
+>Using template metaprogramming to detect or depend on API
+>features is brittle and not guaranteed. Neither the standard library nor
+>Abseil provides any guarantee that APIs are stable in the face of template
+>metaprogramming. Use with caution.
+
+## Type Trait Usage
+
+Type traits were introduced in C++11 to provide compile-time inspection of the
+properties of types. This header file contains two sets of abstractions:
+
+* C++11 compatible versions of `<type_traits>` methods that were either not
+  supported or in C++11 or were not fully-supported.
+* C++11 compatible definitions of C++14 and C++17 `<type_traits>` aliases
+
+## Type Traits Class Templates
+
+* `absl::void_t` provides a version of the C++17 `std::void_t` utility
+  metafunction.
+* `absl::conjunction`, `absl::disjunction` and `absl::negation` provide versions
+  of the C++17 abstractions for performing compile-time logical operations.
+* `absl::is_trivially_destructible`, `absl::is_trivially_default_constructible`,
+  `absl::is_trivially_assignable`, and `absl::is_trivially_copy_assignable`
+  provide versions of these type traits metafunctions that include fixes for
+  platforms that did not fully-implement them.
+
+## C++14 `_t` type aliases
+
+The Abseil `meta` library provides C++11 versions of `<type_traits>` aliases
+added to C++14. These aliases allow you to more easily (and intuitively) get
+the type of a `type_traits` class template.
+
+For example:
+
+```cpp
+// decay_t is the type of std::decay<T>
+template <typename T>
+using decay_t = typename std::decay<T>::type;
+```
+
+The Abseil `meta` library provides aliases for the following type traits that
+yield a type:
+
+* `absl::remove_cv_t`
+* `absl::remove_const_t`
+* `absl::remove_volatile_t`
+* `absl::add_cv_t`
+* `absl::add_const_t`
+* `absl::add_volatile_t`
+* `absl::remove_reference_t`
+* `absl::add_lvalue_reference_t`
+* `absl::add_rvalue_reference_t`
+* `absl::remove_pointer_t`
+* `absl::add_pointer_t`
+* `absl::make_signed_t`
+* `absl::make_unsigned_t`
+* `absl::remove_extent_t`
+* `absl::remove_all_extents_t`
+* `absl::aligned_storage_t`
+* `absl::decay_t`
+* `absl::enable_if_t`
+* `absl::conditional_t`
+* `absl::common_type_t`
+* `absl::underlying_type_t`
+* `absl::result_of_t`

--- a/docs/cpp/guides/numeric.md
+++ b/docs/cpp/guides/numeric.md
@@ -1,0 +1,60 @@
+---
+title: The Numeric Library
+layout: docs
+sidenav: side-nav-cpp.html
+type: markdown
+---
+
+## The Numeric Library
+
+The `//absl/numeric` library provides only one header file at this time:
+
+* int128.h provides 128-bit integer types
+
+## 128-bit Integers
+
+The `int128.h` header file defines 128-bit integer types, for use until
+intrinsic 128-bit types are part of the C++ standard. Currently, this file
+defines only one type: `uint128`, an unsigned 128-bit integer; a signed 128-bit
+integer is forthcoming.
+
+### `uint128`
+
+The `uint128` type defines an unsigned 128-bit integer. The API is meant to
+mimic an intrinsic type as closely as possible, so that any forthcoming
+`uint128_t` can be a drop-in replacement. (`uint128` will be removed once C++
+supports such a type.)
+
+NOTE: code written with this type will continue to compile once `unint128_t`
+is introduced, provided the replacement helper functions `Uint128(Low|High)64()`
+and `MakeUint128()` are made.
+
+A `uint128` supports the following:
+
+* Implicit construction from integral types
+* Explicit conversion to integral types
+
+Additionally, if your compiler supports the `__int128` type extension, `uint128`
+is interoperable with that type.
+
+128-bit integer literals are not yet a part of the C++ language. As a result,
+to construct a 128-bit unsigned integer with a value greater than or equal to
+2^64, you will need to use the `absl::MakeUint128()` factory function.
+
+Examples:
+
+```cpp
+uint64_t a;
+
+// Implicit conversion from uint64_t OK
+uint128 v = a;
+
+// Error: Implicit conversion to uint64_t not OK
+uint64_t b = v;
+
+// Explicit conversion to uint64_t OK
+uint64_t i = static_cast<uint64_t>(v);
+
+// Construct a value of 2^64
+absl::uint128 big = absl::MakeUint128(1, 0);
+```

--- a/docs/cpp/platforms/feature_checks.md
+++ b/docs/cpp/platforms/feature_checks.md
@@ -64,7 +64,7 @@ When writing preprocessor conditionals, you can either whitelist all platforms
 where a given feature is available, or blacklist all platforms where a given
 feature is missing. Either option has pros and cons:
 
-|----| whitelist |blacklist|
+|| whitelist |blacklist|
 |----|------------|----------|
 |pros|Generally safe, and more likely to build on a new platform.|The compilation fails if a new platform doesn’t support the feature.|
 |cons|The whitelist needs to be extended for each new platform.|Compilation might succeed but runtime behavior might be unexpected, if the interface exists but the implementation is problematic.|

--- a/docs/cpp/quickstart.md
+++ b/docs/cpp/quickstart.md
@@ -47,7 +47,7 @@ repository on GitHub:
 # Change to the directory where you want to create the code repository
 $ cd ~
 $ mkdir Source; cd Source
-$ git clone  https://github.com/abseil/abseil-cpp.git
+$ git clone https://github.com/abseil/abseil-cpp.git
 Cloning into 'abseil-cpp'...
 remote: Total 1935 (delta 1083), reused 1935 (delta 1083)
 Receiving objects: 100% (1935/1935), 1.06 MiB | 0 bytes/s, done.


### PR DESCRIPTION
Included changes:

200080696(shreck):	Small fixes to numeric markdown
200056645(shreck):	Fixes for copybara push. Breaks out meta and numeric into own guides.
199656897(shreck):	Fix dash in cell
199335086(shreck):	Add Design Note for the str_format library
199177262(shreck):	Reorganize types overview to allow variant developer guide

PiperOrigin-RevId: 200080696
Change-Id: I4b1110bf87aed1a0c5d7875d5d18866d79bf1438