### PR TITLE
Punctuate and format a bit more / differently

### DIFF
--- a/_posts/2018-05-31-regular-types.md
+++ b/_posts/2018-05-31-regular-types.md
@@ -828,7 +828,7 @@ If you have got the option, make your value types Regular and thread-compatible
 with no mutable or shared state. Do not take any of the above as justification
 to break that commandment lightly.
 
-That said, Regular as everyone describes it does gloss over some things - we
+That said, Regular - as everyone describes it - does gloss over some things: we
 operate on Regular types by reference in standard algorithms constantly, and
 those operations aren't safe without some form of structural knowledge of the
 program. Usually that knowledge is of the form "this instance isn't shared to

--- a/_posts/2018-05-31-regular-types.md
+++ b/_posts/2018-05-31-regular-types.md
@@ -579,7 +579,7 @@ Given a `const T` (and some program knowledge), we can perform any operation
 it or any of its API preconditions. Regular+thread-compatible types allow us
 this invariant with no constraints on the program or that operation. Lesser
 invariants require more knowledge - in return we tend to get lower-overhead,
-which is a very C++ style of tradeoff.
+which is a very C++-style of tradeoff.
 
 ## Evaluating `string_view`
 

--- a/_posts/2018-05-31-regular-types.md
+++ b/_posts/2018-05-31-regular-types.md
@@ -53,8 +53,8 @@ type, which matches the built-in type semantics, thereby making our user-defined
 types behave like built-in types as well."
 
 A vastly-simplified summary, that has become popular in C++ design in later
-years, is "do as the ints do." Generally speaking, for a snippet of generic code
-operating on some type `T`, if it works properly on ints and also works properly
+years, is "do as the `int`s do." Generally speaking, for a snippet of generic code
+operating on some type `T`, if it works properly on `int`s and also works properly
 for your new type (similarly bug-free/comprehensible/etc.), you've designed a
 reasonable type.
 
@@ -202,7 +202,7 @@ traditional logician. In general, we focus on predicates that observe "the
 value" rather than the identity of the instance.
 
 Stepanov goes on to describe the built-in notion of equality for most types:
-bitwise equality for ints and pointers. Floating point values are glossed over a
+bitwise equality for `int`s and pointers. Floating-point values are glossed over a
 bit via "although there are sometimes minor deviations like distinct positive
 and negative zero representations." From this as a basis, we can begin to build
 up a definition of equality for aggregates, but immediately get into trouble
@@ -343,7 +343,7 @@ of its API may result in a data race.
     type causes a data race. Any call to a non-`const` API means that instance
     must be used with external synchronization. C++ guarantees that standard
     library types are at least thread-compatible. This follows from the general
-    pattern of Regular design, and "do as the ints do" as `int` is
+    pattern of Regular design, and "do as the `int`s do" as `int` is
     thread-compatible. In most cases, this is in-line with the philosophy of
     C++ - you do not pay for what you do not use. If you operate on an
     `optional<int>`, you can be sure that it isn't grabbing a mutex. On the

--- a/_posts/2018-05-31-regular-types.md
+++ b/_posts/2018-05-31-regular-types.md
@@ -681,7 +681,7 @@ still behaves as if it were Regular.
 
 ## Non-owning Reference Parameters
 
-C++ is a language that is very concerned with 2 things: types, and efficiency.
+C++ is a language that is very concerned with 2 things: types and efficiency.
 The type system for C++ is more complex than most other languages by a
 significant margin: this is the only mainstream language that I can imagine
 where it's reasonable to envision a proposal for an infinite family of Null

--- a/_posts/2018-05-31-regular-types.md
+++ b/_posts/2018-05-31-regular-types.md
@@ -125,7 +125,7 @@ era. This is true even though `int` doesn’t have a move constructor: it is
 still move constructible (can be constructed from a temporary), and this is
 even the proper design for the type. Move+copy should be considered an overload
 set for optimization purposes. For more information, see
-[TotW 148](/tips/148))
+[TotW 148](/tips/148).
 
 In either case, it's important to bear a few (related) ideas in mind:
 


### PR DESCRIPTION
Make all `int` and `const` appear in backticks. Alter a few bits of punctuation.