### PR TITLE
Fix broken link on main page.

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -7,7 +7,7 @@
       <a href="{{ site.baseurl }}/about">
     	  <button class="btn btn-abseil waves-effect btn-hero">LEARN MORE</button>
       </a>
-      <a href="{{site.baseurl}}/docs/cpp.html">
+      <a href="{{site.baseurl}}/docs/cpp">
         <button class="btn btn-abseil waves-effect btn-hero">GET STARTED</button>
       </a>
   </div>


### PR DESCRIPTION
Right now, the [main page](https://abseil.io) has a link "Get started" that [points to a non-existing location](https://abseil.io/docs/cpp.html). This changes it to point to the right (?) [place](https://abseil.io/docs/cpp/).