### PR TITLE
Export of internal doc changes to Abseil OSS:

### DIFF
--- a/about/design/swisstables.md
+++ b/about/design/swisstables.md
@@ -118,7 +118,7 @@ In STL containers, `emplace()` will almost always:
 We avoid this allocation in all cases where the key can be inferred from the
 arguments of `emplace()` without running user-defined constructors.
 
-{% raw %}
+<!--{% raw %}-->
 ```c++
 absl::flat_hash_map<int64, string> m = {{0, ""}};
 // No objects of type `string` are constructed in the following code.
@@ -128,7 +128,7 @@ m.emplace(std::piecewise_construct,
           std::forward_as_tuple(0),
           std::forward_as_tuple("abc"));
 ```
-{% endraw %}
+<!--{% endraw %}-->
 
 The same optimization is applied for `insert()` operations.
 

--- a/docs/cpp/guides/container.md
+++ b/docs/cpp/guides/container.md
@@ -34,8 +34,8 @@ They provide several advantages over the `std::unordered_*` containers:
 The set of Swiss table containers support the same overload set as
 `std::unordered_map` for construction and assignment:
 
+<!--{% raw %}-->
 ```c++
-{% raw %}
 // Examples using node_hash_set and node_hash_map are equivalent
 
 // Default constructor
@@ -83,8 +83,8 @@ absl::flat_hash_set<std::string> set7(v.begin(), v.end());
 
 std::vector<std::pair<int, std::string>> v = {{1, "a"}, {2, "b"}};
 absl::flat_hash_map<int, std::string> set7(v.begin(), v.end());
-{% endraw %}
 ```
+<!--{% endraw %}-->
 
 ## `absl::flat_hash_map` and `absl::flat_hash_set`
 

--- a/docs/cpp/tools/api-upgrades.md
+++ b/docs/cpp/tools/api-upgrades.md
@@ -1,0 +1,98 @@
+---
+title: "C++ Automated Upgrade Guide"
+layout: docs
+sidenav: side-nav-cpp.html
+type: markdown
+---
+
+# C++ Automated Upgrade Guide
+
+Abseil notes in its
+[Compatibility Guidelines][compatibility] that we
+will strive not to break API compatibility. In particular, we noted that we
+would “never break an API in a single change ... We will introduce a new API and
+a tool, wait some time, and then remove the old.” Until now, that tool has been
+unspecified (as we haven’t yet had any true breaking changes), but we are now
+ready to outline the process and tooling we will use to effect such API-breaking
+changes, when necessary.
+
+The process will consist of two steps, a deprecation followed by an API removal.
+
+The deprecation process consists of the following:
+
+* A change to the API itself. In most cases, we will aim to have both the
+  deprecated API and the replacement API available concurrently (for example,
+  via a separate overload).
+* An associated LLVM [clang-tidy][clang-tidy] check (or checks) living upstream
+  in LLVM’s repository to warn or change usages of the deprecated API to the
+  replacement.
+* Documentation on our [C++ Upgrade Tools][upgrade-tools] page denoting the
+  availability of the tool, and, if necessary, any notes for effecting the
+  change without clang-tidy if such a change cannot be sufficiently automated.
+* An announcement blog post noting the change and containing links to the
+  associated clang-tidy checks and documentation.
+
+At a later time, based on the LLVM release cycle, we will remove the deprecated
+API, which will consist of the following:
+
+* Removal of the deprecated API from Abseil itself.
+* Additional communication via a blog post announcing this formal removal of the
+  deprecated API.
+
+The deprecation and removal process is outlined in more detail below.
+
+## Adding LLVM Clang Tidy Checks
+
+When we determine that an API-breaking change is either necessary or
+sufficiently beneficial, we will first introduce a suitable replacement and
+release that code to Abseil (if possible).  We will always strive to make
+refactoring of existing code non-atomic. Such refactoring should therefore not
+require upgrading your version of Abseil.
+
+Once a replacement is available, we will create a new clang-tidy check (or
+checks) that will automate as much of the upgrade process for our users as
+possible.  All Abseil API-breaking Clang Tidy checks will be prefixed by
+“abseil-upgrade-” and listed on the
+[Clang Tidy Checks documentation page][clang-tidy-checks].
+
+Wherever it is deemed safe to do so, the check will provide fixes that
+clang-tidy can apply automatically.  As this is C++, edge cases such as macro
+bodies and complicated template logic may require manual changes. In such
+situations, the clang-tidy check will still provide warning diagnostics to flag
+deprecated uses, just without an automated fix. In those cases, we will provide
+documentation for effecting the needed change.
+
+It’s important to note that code will continue to compile after fixes without
+updating any project dependencies.  As a result, upgrade checks can be used as
+part of pre-submit testing and / or be included in the usual clang-tidy workflow
+to prevent backsliding.
+
+## Communicating API-Breaking Changes
+
+After a new check undergoes review and lands upstream on the LLVM site, we will
+announce the details with an [Abseil blog post][abseil-blog] of the
+upcoming change as well as instructions for upgrading. Any associated
+documentation regarding the change will be noted within the
+[C++ Upgrade Tools][upgrade-tools] page. That guide will contain a list of all
+changes.
+
+Once posted on both LLVM and the Abseil blog, we will wait an appropriate amount
+of time for the check to become available through the regular LLVM release
+cycle. Once available, users can obtain (e.g. [download from llvm][llvm]) and
+run a sufficiently fresh version of clang-tidy to generate the needed changes to
+their code.
+
+Prior to releasing any API breaking changes, we will attempt to ensure that the
+upgrade check, the old API, and its replacement coexist for at least one LTS
+branch cut.  Then, when the time comes to actually remove the deprecated API,
+we will add a release notes blog post as a helpful reminder.  Similar notes will
+be repeated as part of any LTS branch cut announcements that include API
+breaking changes.
+
+[compatibility]: /about/compatibility
+[clang-tidy]: http://clang.llvm.org/extra/clang-tidy/
+[upgrade-tools]: upgrades/
+[clang-tidy-checks]: https://clang.llvm.org/extra/clang-tidy/checks/list.html
+[abseil-blog]: https://abseil.io/blog/
+[llvm]: http://releases.llvm.org/
+

--- a/docs/cpp/tools/index.md
+++ b/docs/cpp/tools/index.md
@@ -8,3 +8,5 @@ type: markdown
 # C++ Tools Guides
 
 * [Abseil Clang-tidy Checks](clang-tidy)
+* [C++ Automated Upgrade Guide](api-upgrades)
+* [C++ Upgrade Tools](upgrades/index)

--- a/docs/cpp/tools/upgrades/duration-conversions.md
+++ b/docs/cpp/tools/upgrades/duration-conversions.md
@@ -1,0 +1,74 @@
+---
+title: "Duration Conversion Upgrade Tool"
+layout: docs
+sidenav: side-nav-cpp.html
+type: markdown
+---
+
+# Duration Conversion Upgrade Tool
+
+The Abseil Duration Conversion upgrade tool finds calls to `absl::Duration`
+arithmetic operators and factories that rely on deprecated overloads. These
+calls invoke implicit conversions that can lead to subtle bugs. After upcoming
+API changes, an explicit cast will be required for affected call sites to
+continue compiling.
+
+The clang-tidy check to apply necessary changes is
+[abseil-upgrade-duration-conversions][duration-conversions].
+
+## Background
+
+The arithmetic operators (`*=`, `/=`, `*`, and `/`) for `absl::Duration`
+currently have templated overloads to accept an argument of class type that is
+convertible to any arithmetic type. The implementation always converts such an
+argument to an `int64_t`. This happens even in a case such as
+`std::atomic<float>`, which leads to loss of precision:
+
+```c++
+absl::Duration d;
+d *= std::atomic<float>(3.5f);  // actually multiplies by 3!
+```
+
+The following factory functions have a similar issue we are addressing:
+
+*   `absl::Nanoseconds`
+*   `absl::Microseconds`
+*   `absl::Milliseconds`
+*   `absl::Seconds`
+*   `absl::Minutes`
+*   `absl::Hours`
+
+Currently, each of these factories has an overload that accepts an `int64_t`.
+This overload ends up being chosen for calls with an argument of class type that
+is convertible to any arithmetic type. As before, this can lead to unexpected
+and unintended behavior that is difficult to spot at the call site.
+
+In the case of both the operators and factories, current calls using floating
+point types or integral types are unaffected by these issues.
+
+## API Changes
+
+These operators and factories will be changed to only accept arithmetic types in
+order to prevent unintended behavior. The fix ahead of this change is to
+explicitly cast arguments of class type that are currently getting passed to the
+affected APIs.
+
+You can use the released clang-tidy check to do this in an automated way.
+However, if clang-tidy is not an option, here is an example of the manual fixes
+required:
+
+```c++
+std::atomic<int> a;
+absl::Duration d = absl::Milliseconds(a);
+d *= a;
+```
+
+becomes
+
+```c++
+std::atomic<int> a;
+absl::Duration d = absl::Milliseconds(static_cast<int>(a));
+d *= static_cast<int>(a);
+```
+
+[duration-conversions]: https://clang.llvm.org/extra/clang-tidy/checks/abseil-upgrade-duration-conversions.html

--- a/docs/cpp/tools/upgrades/index.md
+++ b/docs/cpp/tools/upgrades/index.md
@@ -1,0 +1,28 @@
+---
+title: "C++ Upgrade Tools"
+layout: docs
+sidenav: side-nav-cpp.html
+type: markdown
+---
+
+# C++ Upgrade Tools
+
+This page lists C++ upgrade tools we have released for Abseil to effect any
+API-Breaking changes we need to make in the codebase. These tools are listed in
+chronological order.
+
+NOTE: consult the [C++ Automated Upgrade Guide][api-upgrades-guide] for
+information on how to use these tools and the process we follow for making
+necessary upgrades to Abseil.
+
+## Tools Listing
+
+* Dec, 2018: [abseil-upgrade-duration-conversions](duration-conversions)
+
+## More Information
+
+For information on how to run an Abseil clang-tidy check on your codebase,
+see [Using clang-tidy Checks for Abseil][clang-tidy-guide].
+
+[api-upgrades-guide]: /docs/cpp/tools/api-upgrades
+[clang-tidy-guide]: /docs/cpp/tools/clang-tidy


### PR DESCRIPTION
rpc://team/absl-team/Abseil-Docs

Included changes:

226213946(shreck):	Fix escaping of {{ in samples that cause Liquid errors on server
226210021(shreck):	Develop initial documentation for API breaking changes process:

PiperOrigin-RevId: 226213946
Change-Id: I8e80a0a98bb9955fb9538da876f33fa82540bdde