### PR TITLE
TOTW #49: Make it clear that ADL does not consider enclosing scopes

### DIFF
--- a/_posts/2017-11-09-totw-49.md
+++ b/_posts/2017-11-09-totw-49.md
@@ -94,12 +94,15 @@ seen by overload resolution.
 An important implication of the scoped search order is that overloads in a scope
 appearing earlier in the search order will hide overloads from later scopes.
 
-## Argument-Dependent Lookup
+## Argument-Dependent Lookup (ADL)
 
 If a function call passes arguments, a few more parallel name lookups are
-launched. These extra lookups begin in each associated namespace of each of the
-function call’s arguments. A scope containing a name match doesn't stop all of
-the lookups, only the one that encountered the match.
+launched. These extra lookups consider each associated namespace of each of the
+function call’s arguments. Unlike lexical scope name lookup, these argument-
+dependent lookups do not proceed to enclosing scopes.
+
+Results of lexical scope name lookup and all ADLs are merged together, to form 
+the final set of function overloads.
 
 ## The Simple Case
 


### PR DESCRIPTION
I especially do not like "These extra lookups **begin** in each associated namespace", because it makes me feel like they will continue to search something after an associated namespace, while in fact they won't.