### PR TITLE
Fix broken link to cpp guide in the site footer.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,7 +19,7 @@
             <div class="col-md-3 col-sm-3 col-xs-12 footer-resources">
                 <ul class="toggle">
                     <a href="{{ site.baseurl }}/docs/"><p class="right-link-headers">Dev Guides</p></a>
-                    <li><a href="{{ site.baseurl }}/docs/cpp.html"><p>C++</p></a></li>
+                    <li><a href="{{ site.baseurl }}/docs/cpp/"><p>C++</p></a></li>
                     <li><a href="{{ site.baseurl }}/blog/"><p>Abseil Blog</p></a></li>
                 </ul>
                 </ul>


### PR DESCRIPTION
I noticed the footer link 404'd, fixing it. 