### PR TITLE
Export of internal doc changes to Abseil OSS:

### DIFF
--- a/docs/cpp/guides/time.md
+++ b/docs/cpp/guides/time.md
@@ -66,7 +66,7 @@ in the example below and illustrated in Figure 1.
 
 ```
 Civil Time = F(Absolute Time, Time Zone)
-Absolute Time = F(Civil Time, Time Zone)
+Absolute Time = F'(Civil Time, Time Zone)
 ```
 
 ![Fundamental Time Concepts](images/time-concepts.png) Figure 1

--- a/docs/cpp/quickstart-cmake.md
+++ b/docs/cpp/quickstart-cmake.md
@@ -159,10 +159,10 @@ target_link_libraries(hello_world absl::strings)
 For more information on how to create CMakeLists.txt files, consult the
 [CMake Tutorial](https://cmake.org/cmake-tutorial/).
 
-Build our CMake build files:
+Configure the CMake build from a fresh binary directory. This configuration is
+called an "out of source" build and is the preferred method for CMake projects.
 
 ```
-# It's often good practice to build files from a separate build directory
 $ cd ~/Source/TestProject/examples
 $ mkdir build && cd build
 $ cmake ..


### PR DESCRIPTION
rpc://team/absl-team/Abseil-Docs

Included changes:

241729408(Abseil Team):	The same function name F is used both to convert absolute to civil and civil to absolute time, given a fixed time zone. This looks like, given a time zone TZ, F(_, TZ) is an involution, which is false.
241560400(Abseil Team):	Internal change.

PiperOrigin-RevId: 241729408
Change-Id: I6333494450ff1bcd2aaa59fc45fda26cabfc8d56