### PR TITLE
Export of internal doc changes to Abseil OSS:

### DIFF
--- a/docs/cpp/guides/flags.md
+++ b/docs/cpp/guides/flags.md
@@ -122,7 +122,7 @@ ABSL_FLAG(bool, big_menu, true,
           "Include 'advanced' options in the menu listing");
 ABSL_FLAG(std::string, output_dir, "foo/bar/baz/", "output file dir");
 ABSL_FLAG(std::vector<std::string>, languages,
-          {"english", "french", "german"},
+          std::vector({"english", "french", "german"}),
           "comma-separated list of languages to offer in the 'lang' menu");
 ABSL_FLAG(absl::Duration, timeout, absl::Seconds(30), "Default RPC deadline");
 ```


### PR DESCRIPTION
rpc://team/absl-team/Abseil-Docs

Included changes:

249902651(shreck):	        Add flags library document to main C++ guides list
249646985(Abseil Team):	Fix a compile error in the sample code in the flags docs.

PiperOrigin-RevId: 249902651
Change-Id: I0022eb2d570d660260706cc5c27e549a0a197287