### PR TITLE
Export of internal doc changes to Abseil OSS:

### DIFF
--- a/about/design/mutex.md
+++ b/about/design/mutex.md
@@ -65,9 +65,8 @@ void Finish() {
 <pre>
 void Wait() {
   shared_lock_->Lock();
-  shared_lock_->Await(Condition([this]() {
-      return shared_state_ == 1;
-  }));
+  auto shared_state_is_one = [this] { return shared_state_ == 1; };
+  shared_lock_->Await(Condition(&shared_state_is_one));
   shared_lock_->Unlock();
 }
 </pre>

--- a/docs/cpp/guides/flags.md
+++ b/docs/cpp/guides/flags.md
@@ -122,7 +122,7 @@ ABSL_FLAG(bool, big_menu, true,
           "Include 'advanced' options in the menu listing");
 ABSL_FLAG(std::string, output_dir, "foo/bar/baz/", "output file dir");
 ABSL_FLAG(std::vector<std::string>, languages,
-          std::vector({"english", "french", "german"}),
+          std::vector<std::string>({"english", "french", "german"}),
           "comma-separated list of languages to offer in the 'lang' menu");
 ABSL_FLAG(absl::Duration, timeout, absl::Seconds(30), "Default RPC deadline");
 ```
@@ -440,7 +440,7 @@ Example:
 
 ```cpp
 namespace foo {
-enum OutputMode { kPlainText, kHtml };
+enum class OutputMode { kPlainText, kHtml };
 
 // AbslParseFlag converts from a string to OutputMode.
 // Must be in same namespace as OutputMode.
@@ -452,11 +452,11 @@ bool AbslParseFlag(absl::string_view text,
                    OutputMode* mode,
                    std::string* error) {
   if (text == "plaintext") {
-    *mode = kPlainText;
+    *mode = OutputMode::kPlainText;
     return true;
   }
   if (text == "html") {
-    *mode = kHtml;
+    *mode = OutputMode::kHtml;
     return true;
   }
   *error = "unknown value for enumeration";
@@ -469,9 +469,9 @@ bool AbslParseFlag(absl::string_view text,
 // Returns a textual flag value corresponding to the OutputMode `mode`.
 std::string AbslUnparseFlag(OutputMode mode) {
   switch (mode) {
-   case kPlainText: return "plaintext";
-   case kHtml: return "html";
-   default: return SimpleItoa(mode);
+    case OutputMode::kPlainText: return "plaintext";
+    case OutputMode::kHtml: return "html";
+    default: return absl::StrCat(mode);
   }
 }
 }  // namespace foo

--- a/docs/cpp/guides/format.md
+++ b/docs/cpp/guides/format.md
@@ -68,9 +68,9 @@ Usage' guide for information on dynamic formatting.
 ### Conversion Specifiers
 
 The `str_format` library follows the POSIX syntax as used within the
-[POSIX `printf` specification][1], which specifies the makeup of a format
-conversion specifier. A format conversion specifier is a string of the following
-form:
+[POSIX `printf()` family specification][1], which specifies the makeup of a
+format conversion specifier. A format conversion specifier is a string of the
+following form:
 
 *   The `%` character
 *   An optional positional specifier of the form `n$`, where `n` is a
@@ -277,4 +277,4 @@ if (fileHandle!=nullptr)
 }
 ```
 
-[1]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/printf.html
+[1]: http://pubs.opengroup.org/onlinepubs/9699919799/functions/fprintf.html

--- a/docs/cpp/platforms/platforms.md
+++ b/docs/cpp/platforms/platforms.md
@@ -153,6 +153,14 @@ Archiecture, Specific Compiler, and Standard Library implementation.
 
 ### Windows
 
+<p style="background-color: #89CFF0; padding: 5px; width: 80%;" id="id06272019">
+<br/>
+On Windows platforms, Abseil does not include <code>winsock.h</code>, as it also
+pulls in <code>windows.h</code> (and defines a set of macros that may conflict
+with Abseil users). Instead, we forward declare <code>timeval</code> and
+require Windows users to explicitly include <code>winsock2.h</code> themselves.
+</p>
+
 **Supported**
 
 <table width="80%">
@@ -211,3 +219,6 @@ Archiecture, Specific Compiler, and Standard Library implementation.
     </tr>
   </tbody>
 </table>
+
+<!-- Styles for dated updates/changes to platform support -->
+<style>#id06302019:before { content: "06/27/2019";font-weight:bold; }</style>


### PR DESCRIPTION
rpc://team/absl-team/Abseil-Docs

Included changes:

255255919(shreck):	        Add platform notice removing winsock2.h
255008379(Abseil Team):	Make flag example code work pre-C++17. (Class template argument deduction doesn't work until C++17.)
254689410(Abseil Team):	Fix documentation: it's not possible to construct an absl::Condition directly from a capturing lambda.
254439885(shreck):	        Add caveat on winsock2.h
253966485(Abseil Team):	Internal change
253078755(Abseil Team):	Since enum class is preferred (https://abseil.io/tips/86), it makes sense to update this example. Also using absl::StrCat instead of SimpleItoa.
253041344(Abseil Team):	Clarify documentation relating to the output of the various printing functions.

PiperOrigin-RevId: 255255919
Change-Id: Ic7ddfd33fcdb0d255ea75839f1b6d189a90cadf9