### PR TITLE
Abseil Docs Push for week of August 12

### DIFF
--- a/about/compatibility.md
+++ b/about/compatibility.md
@@ -101,25 +101,24 @@ you misuse Abseil APIs, you're on your own.
 
 ## What We Promise
 
-* **We will support our code for at least 5 years**. We will support language
-  versions, compilers, platforms, and workarounds as needed for 5 years after
-  their replacement is available, when possible. If it is technically infeasible
-  (such as support for MSVC before 2015, which has limited C++11 functionality),
-  those will be noted specifically. After 5 years we will stop support and may
-  remove workarounds. `ABSL_HAVE_THREAD_LOCAL` is a good example: the base 
-  language feature works on everything except XCode prior to XCode 8 ; once
-  XCode 8 is out for 5 years, we will drop that workaround support.
-* **We will not break API compatibility.** If we must, we will ship a tool to
-  automate the upgrade to a preferred API. We will never break that API in a
-  single change - we believe in non-atomic refactoring. We will introduce the
-  new API and the tool, wait some time, and then remove the old.
-* **We promise to provide good forward-compatibility with the C++
-  standard.**
-* **We promise at least the basic-exception guarantee.** Although
-  Google is part of the minority of the C++ community that doesn't use
-  exceptions, we recognize that it **is** a minority and believe that
-  code is often better when it's exception-safe. We've done our best
-  to make things exception-safe. However, we won't contort things to
-  support all possible exceptions &mdash; if you have a hash functor
-  or `operator==` that throws, we may just mark it `noexcept` instead.
-
+*   **We will support our code for at least 5 years**. We will support language
+    versions, compilers, platforms, and workarounds as needed for 5 years after
+    their replacement is available, when possible. If it is technically
+    infeasible (such as support for MSVC before 2015, which has limited C++11
+    functionality), those will be noted specifically. After 5 years we will stop
+    support and may remove workarounds. `ABSL_HAVE_THREAD_LOCAL` is a good
+    example: the base language feature works on everything except Xcode prior to
+    Xcode 8 ; once Xcode 8 is out for 5 years, we will drop that workaround
+    support.
+*   **We will not break API compatibility.** If we must, we will ship a tool to
+    automate the upgrade to a preferred API. We will never break that API in a
+    single change - we believe in non-atomic refactoring. We will introduce the
+    new API and the tool, wait some time, and then remove the old.
+*   **We promise to provide good forward-compatibility with the C++ standard.**
+*   **We promise at least the basic-exception guarantee.** Although Google is
+    part of the minority of the C++ community that doesn't use exceptions, we
+    recognize that it **is** a minority and believe that code is often better
+    when it's exception-safe. We've done our best to make things exception-safe.
+    However, we won't contort things to support all possible exceptions &mdash;
+    if you have a hash functor or `operator==` that throws, we may just mark it
+    `noexcept` instead.

--- a/docs/cpp/guides/container.md
+++ b/docs/cpp/guides/container.md
@@ -43,6 +43,7 @@ These ordered containers are designed to be more efficient replacements for
 and [`std::set`](https://en.cppreference.com/w/cpp/container/set) in most cases.
 Specifically, they provide several advantages over the ordered `std::`
 containers:
+
 *   Provide lower memory overhead in most cases than their STL equivalents.
 *   Are generally more cache friendly (and hence faster) than their STL
     equivalents.

--- a/docs/cpp/platforms/macros.md
+++ b/docs/cpp/platforms/macros.md
@@ -77,14 +77,14 @@ References:
 
 ## Operating Systems
 
-|**Macro**|**Operating System**|**Compiler**|
-|------------|----------|----------|
-|`__ANDROID__`|Android|Android NDK|
-|`__APPLE__`|MacOS, iOS|GNU C, Intel C++, and Apple LLVM|
-|`_WIN32`|Windows|For both 32-bit and 64-bit environments|
-|`__linux__`|Linux|Android NDK, GNU C, Clang/LLVM|
-|`__ros__`|Akaros||
-|`__Fushsia__`|Fuchsia||
+**Macro**     | **Operating System** | **Compiler**
+------------- | -------------------- | ---------------------------------------
+`__ANDROID__` | Android              | Android NDK
+`__APPLE__`   | macOS, iOS           | GNU C, Intel C++, and Apple LLVM
+`_WIN32`      | Windows              | For both 32-bit and 64-bit environments
+`__linux__`   | Linux                | Android NDK, GNU C, Clang/LLVM
+`__ros__`     | Akaros               |
+`__Fushsia__` | Fuchsia              |
 
 References:
 

--- a/docs/cpp/platforms/platforms.md
+++ b/docs/cpp/platforms/platforms.md
@@ -49,7 +49,7 @@ Linux:
 * clang < 5.0: `-std=c++1z`
 * gcc, clang 5.0+: `-std=c++17`
 
-Mac OSX:
+macOS:
 
 * gcc, clang: `-std=c++11`
 * gcc, clang: `-std=c++14`
@@ -106,7 +106,7 @@ Archiecture, Specific Compiler, and Standard Library implementation.
   </tbody>
 </table>
 
-### Mac OSX / Darwin Family
+### macOS / Darwin Family
 
 **Supported**
 
@@ -120,13 +120,13 @@ Archiecture, Specific Compiler, and Standard Library implementation.
       <th>Standard Libraries</th>
     </tr>
     <tr>
-      <td>Mac OSX 10.7+, endian-neutral, 64-bit</td>
-      <td>XCode 7.3.1+</td>
+      <td>macOS 10.7+, endian-neutral, 64-bit</td>
+      <td>Xcode 7.3.1+</td>
       <td>libc++</td>
     </tr>
     <tr>
       <td>iOS 7+, endian-neutral, 64-bit</td>
-      <td>XCode 7.3.1+</td>
+      <td>Xcode 7.3.1+</td>
       <td>libc++</td>
     </tr>
   </tbody>
@@ -145,7 +145,7 @@ Archiecture, Specific Compiler, and Standard Library implementation.
     </tr>
     <tr>
       <td>watchOS 2+, endian-neutral, 64-bit</td>
-      <td>XCode 7.3.1+</td>
+      <td>Xcode 7.3.1+</td>
       <td>libc++</td>
     </tr>
   </tbody>

--- a/docs/cpp/quickstart-cmake.md
+++ b/docs/cpp/quickstart-cmake.md
@@ -17,17 +17,17 @@ project uses [Bazel](https://bazel.build/) instead, please find the
 
 Running the Abseil code within this tutorial requires:
 
-* A compatible platform (e.g. Windows, Mac OS X, Linux, etc.). Most platforms
-  are fully supported. Consult the
-  [Platforms Guide](platforms/platforms) for more information.
-* A compatible C++ compiler *supporting at least C++11*. Most major compilers
-  are supported.
-* [Git](https://git-scm.com/) for interacting with the Abseil source code
-  repository, which is contained on [GitHub](http://github.com). To install Git,
-  consult the [Set Up Git](https://help.github.com/articles/set-up-git/) guide
-  on GitHub.
-* [CMake](https://cmake.org/) for building your project and Abseil.  Abseil
-  supports CMake 3.5+.
+*   A compatible platform (e.g. Windows, macOS, Linux, etc.). Most platforms are
+    fully supported. Consult the [Platforms Guide](platforms/platforms) for more
+    information.
+*   A compatible C++ compiler *supporting at least C++11*. Most major compilers
+    are supported.
+*   [Git](https://git-scm.com/) for interacting with the Abseil source code
+    repository, which is contained on [GitHub](http://github.com). To install
+    Git, consult the [Set Up Git](https://help.github.com/articles/set-up-git/)
+    guide on GitHub.
+*   [CMake](https://cmake.org/) for building your project and Abseil. Abseil
+    supports CMake 3.5+.
 
 ## Getting the Abseil Code
 

--- a/docs/cpp/quickstart.md
+++ b/docs/cpp/quickstart.md
@@ -7,9 +7,9 @@ type: markdown
 
 # C++ Quickstart
 
-Note: this Quickstart uses Bazel as the official build system for Abseil,
-which is supported on most major platforms (Linux, Windows, MacOS, for example)
-and compilers. The Abseil source code assumes you are using Bazel and contains
+Note: this Quickstart uses Bazel as the official build system for Abseil, which
+is supported on most major platforms (Linux, Windows, macOS, for example) and
+compilers. The Abseil source code assumes you are using Bazel and contains
 `BUILD.bazel` files for that purpose.
 
 This document is designed to allow you to get the Abseil development
@@ -23,15 +23,15 @@ Abseil also supports building with CMake.  For information, please see the
 
 Running the Abseil code within this tutorial requires:
 
-* A compatible platform (e.g. Windows, Mac OS X, Linux, etc.). Most platforms
-  are fully supported. Consult the
-  [Platforms Guide](platforms/platforms) for more information.
-* A compatible C++ compiler *supporting at least C++11*. Most major compilers
-  are supported.
-* [Git](https://git-scm.com/) for interacting with the Abseil source code
-  repository, which is contained on [GitHub](http://github.com). To install Git,
-  consult the [Set Up Git](https://help.github.com/articles/set-up-git/) guide
-  on GitHub.
+*   A compatible platform (e.g. Windows, macOS, Linux, etc.). Most platforms are
+    fully supported. Consult the [Platforms Guide](platforms/platforms) for more
+    information.
+*   A compatible C++ compiler *supporting at least C++11*. Most major compilers
+    are supported.
+*   [Git](https://git-scm.com/) for interacting with the Abseil source code
+    repository, which is contained on [GitHub](http://github.com). To install
+    Git, consult the [Set Up Git](https://help.github.com/articles/set-up-git/)
+    guide on GitHub.
 
 Although you are free to use your own build system, most of the documentation
 within this guide will assume you are using [Bazel](https://bazel.build/).


### PR DESCRIPTION
Export of internal doc changes to Abseil OSS:
rpc://team/absl-team/Abseil-Docs

Included changes:

262389450(Abseil Team):	Update the absl codebase to use proper marketing names for macOS and Xcode
262337879(Abseil Team):	Fix markdown formatting