### PR TITLE
Export of internal doc changes to Abseil OSS

### DIFF
--- a/docs/cpp/guides/strings.md
+++ b/docs/cpp/guides/strings.md
@@ -147,8 +147,8 @@ Examples:
 ```cpp
 // Stores results in a std::set<std::string>, which also performs de-duplication
 // and orders the elements in ascending order.
-std::set<std::string> a = absl::StrSplit("b,a,c,a,b", ',');
-// v[0] == "a", v[1] == "b", v[3] == "c"
+std::set<std::string> s = absl::StrSplit("b,a,c,a,b", ',');
+// s[0] == "a", s[1] == "b", s[3] == "c"
 
 // Stores results in a map. The map implementation assumes that the input
 // is provided as a series of key/value pairs. For example, the 0th element

--- a/docs/cpp/platforms/platforms.md
+++ b/docs/cpp/platforms/platforms.md
@@ -81,11 +81,16 @@ Archiecture, Specific Compiler, and Standard Library implementation.
     </tr>
     <tr>
       <td>Linux, little-endian, 64-bit</td>
-      <td>gcc 4.8+<br/>clang 3.3+</td>
-      <td>libstdc++<br/>libcxx</td>
+      <td>gcc 4.9+<br/>clang 3.3+</td>
+      <td>libstdc++<br/>libc++</td>
     </tr>
   </tbody>
 </table>
+
+<p style="background-color: #89CFF0; padding: 5px; width: 80%;" id="id08192019">
+<br/>
+Abseil now requires gcc 4.9 or above. Usage of gcc 4.8 is now unsupported.
+</p>
 
 **Best Effort**
 
@@ -215,11 +220,17 @@ themselves.
     </tr>
     <tr>
       <td>Android NDK r11c+</td>
-      <td>gcc 4.8+</td>
+      <td>gcc 4.9+</td>
       <td>libc++, libstdc++</td>
     </tr>
   </tbody>
 </table>
 
+<p style="background-color: #89CFF0; padding: 5px; width: 80%;" id="id08192019">
+<br/>
+Abseil now requires gcc 4.9 or above. Usage of gcc 4.8 is now unsupported.
+</p>
+
 <!-- Styles for dated updates/changes to platform support -->
-<style>#id06302019:before { content: "06/27/2019";font-weight:bold; }</style>
+<style>#id06272019:before { content: "06/27/2019";font-weight:bold; color:black}</style>
+<style>#id08192019:before { content: "08/19/2019";font-weight:bold; color:black}</style>


### PR DESCRIPTION
Export of internal doc changes to Abseil OSS:
rpc://team/absl-team/Abseil-Docs

Included changes:

264469017(shreck):	        Update gcc platform requirements to 4.9
263800131(Abseil Team):	Rename returned set and fix comment about its contents.

Change-Id: Id46b267c5587e005647d1b4990322c8afc4d44a0