### PR TITLE
Fix typo for Fuchsia macro

### DIFF
--- a/docs/cpp/platforms/macros.md
+++ b/docs/cpp/platforms/macros.md
@@ -84,7 +84,7 @@ References:
 `_WIN32`      | Windows              | For both 32-bit and 64-bit environments
 `__linux__`   | Linux                | Android NDK, GNU C, Clang/LLVM
 `__ros__`     | Akaros               |
-`__Fushsia__` | Fuchsia              |
+`__Fuchsia__` | Fuchsia              |
 
 References:
 


### PR DESCRIPTION
There was a typo in the macros file where Fuchsia was misspelled as Fushsia.