### PR TITLE
Export of internal doc changes to Abseil OSS:

### DIFF
--- a/about/releases.md
+++ b/about/releases.md
@@ -9,8 +9,13 @@ type: markdown
 
 Abseil provides its repository as source code, and specifically does not offer
 binary releases. Instead, we encourage you to either "live at head" (build
-from the latest version of Abseil) or, if necessary, build against a known,
-supported branch, known as a Long Term Support (LTS) branch.
+from the latest version of Abseil), or build against a known, supported branch,
+known as a Long Term Support (LTS) branch.
+
+If you must provide Abseil within a binary or library (e.g. you are a package
+manager), we have provided a mechanism to help ensure that any embedded copy of
+Abseil uses the same copy of Abseil. For more information, consult the
+[Abseil Options Guide](/docs/cpp/guides/options).
 
 This document outlines the specifics of what releases we provide, and options
 for how you build and distribute Abseil within your source code, binary, or
@@ -66,6 +71,11 @@ options, listed in order of higher preference:
     * *DISCOURAGED*: Copy Abseil code into your project and provide it within
       your own repository. Obviously, this makes maintenance difficult, though
       not impossible.
+*   Embed a copy of Abseil within your binary. Although discouraged, we
+    understand this is sometimes necessary:<br/><br/>
+    * *ALLOWED*: Embed a copy of Abseil using configurations within the Abseil
+      `options.h` file. Consult the
+      [Abseil Options Guide](/docs/cpp/guides/options).
 
 ## Options for Including Abseil Code In Your Library
 
@@ -87,6 +97,9 @@ between different builds of Abseil.)
   Abseil, that exports no Abseil symbols. This option implies that no Abseil
   types exist within your library's public API, and all Abseil symbols must be
   hidden by the linker.
+* *ALLOWED*: Embed a copy of Abseil using configurations within the Abseil
+  `options.h` file. Consult the
+  [Abseil Options Guide](/docs/cpp/guides/options).
 * *DISCOURAGED*: Distribute a *dynamic* library. Abseil does not support dynamic
   loading or unloading of any shared libraries at this time. We are
   investigating if we can support dynamic loading without unloading. Consult

--- a/docs/cpp/guides/base.md
+++ b/docs/cpp/guides/base.md
@@ -96,6 +96,9 @@ The Base library's configuration header files consist of the following:
   the Abseil [Platforms Guide](/docs/cpp/platforms).
 * `macros.h`<br />
   Provides macros used within Abseil code for language features.
+* `options.h` <br />
+  Provides mechanisms to enforce static configuration of certain implementation
+  details.
 * `optimization.h`<br />
   Provides several platform-dependent macros for implementing
   optimization techniques.

--- a/docs/cpp/guides/index.md
+++ b/docs/cpp/guides/index.md
@@ -17,6 +17,7 @@ all code within Abseil within this guide.
 * [Hash Library](hash)
 * [Meta Library Guide](meta)
 * [Numeric Library Guide](numeric)
+* [Options Guide](options)
 * [Synchronization Guide](synchronization)
 * [StrFormat Guide](format)
 * [Strings Guide](strings)

--- a/docs/cpp/guides/numeric.md
+++ b/docs/cpp/guides/numeric.md
@@ -13,33 +13,26 @@ The `//absl/numeric` library provides only one header file at this time:
 
 ## 128-bit Integers
 
-The `int128.h` header file defines 128-bit integer types, for use until
-intrinsic 128-bit types are part of the C++ standard. Currently, this file
-defines only one type: `uint128`, an unsigned 128-bit integer; a signed 128-bit
-integer is forthcoming.
+The `int128.h` header file defines signed and unsigned 128-bit integer types.
+The APIs are meant to mimic intrinsic types as closely as possible, so that any
+forthcoming standard type can be a drop-in replacement. A key difference is that
+some categories of conversion are explicit, as noted below.
 
 ### `uint128`
 
-The `uint128` type defines an unsigned 128-bit integer. The API is meant to
-mimic an intrinsic type as closely as possible, so that any forthcoming
-`uint128_t` can be a drop-in replacement. (`uint128` will be removed once C++
-supports such a type.)
+The `uint128` type defines an unsigned 128-bit integer supporting the following:
 
-NOTE: code written with this type will continue to compile once `uint128_t`
-is introduced, provided the replacement helper functions `Uint128(Low|High)64()`
-and `MakeUint128()` are made.
-
-A `uint128` supports the following:
-
-* Implicit construction from integral types
-* Explicit conversion to integral types
+*   Implicit conversion from integral types
+*   Explicit conversion to integral types
+*   Explicit conversion to and from floating point types
+*   Overloads for `std::numeric_limits`
 
 Additionally, if your compiler supports the `__int128` type extension, `uint128`
 is interoperable with that type.
 
-128-bit integer literals are not yet a part of the C++ language. As a result,
-to construct a 128-bit unsigned integer with a value greater than or equal to
-2^64, you will need to use the `absl::MakeUint128()` factory function.
+128-bit integer literals are not yet a part of the C++ language. As a result, to
+construct a 128-bit unsigned integer with a value greater than or equal to 2^64,
+you should use the `absl::MakeUint128()` factory function.
 
 Examples:
 
@@ -47,7 +40,7 @@ Examples:
 uint64_t a;
 
 // Implicit conversion from uint64_t OK
-uint128 v = a;
+absl::uint128 v = a;
 
 // Error: Implicit conversion to uint64_t not OK
 uint64_t b = v;
@@ -57,4 +50,48 @@ uint64_t i = static_cast<uint64_t>(v);
 
 // Construct a value of 2^64
 absl::uint128 big = absl::MakeUint128(1, 0);
+
+// Get the high and low 64 bits of a uint128
+uint64_t high = absl::Uint128High64(v);
+uint64_t low = absl::Uint128Low64(v);
+```
+
+### `int128`
+
+The `int128` type defines a signed 128-bit integer supporting the following:
+
+*   Implicit conversion from signed integral types and unsigned types narrower
+    than 128 bits
+*   Explicit conversion from unsigned 128-bit types
+*   Explicit conversion to integral types
+*   Explicit conversion to and from floating point types
+*   Overloads for `std::numeric_limits`
+
+Additionally, if your compiler supports the `__int128` type extension, `int128`
+is interoperable with that type.
+
+128-bit integer literals are not yet a part of the C++ language. As a result, to
+construct a 128-bit signed integer with a value greater than or equal to 2^64,
+you should use the `absl::MakeInt128()` factory function.
+
+Examples:
+
+```cpp
+int64_t a;
+
+// Implicit conversion from int64_t OK
+absl::int128 v = a;
+
+// Error: Implicit conversion to int64_t not OK
+int64_t b = v;
+
+// Explicit conversion to int64_t OK
+int64_t i = static_cast<int64_t>(v);
+
+// Construct a value of 2^64
+absl::int128 big = absl::MakeInt128(1, 0);
+
+// Get the high and low 64 bits of an int128
+int64_t high = absl::Int128High64(v);
+uint64_t low = absl::Int128Low64(v);
 ```

--- a/docs/cpp/guides/options.md
+++ b/docs/cpp/guides/options.md
@@ -1,0 +1,69 @@
+---
+title: "Abseil Option Configurations"
+layout: docs
+sidenav: side-nav-cpp.html
+type: markdown
+---
+
+# Abseil Option Configurations
+
+Abseil provides a file ([`options.h`][options-file]) for static configuration of
+certain implementation details. Such static configurations are not often
+necessary but may be useful for providers of binaries/libraries which wish to
+ensure that their built-upon copies of Abseil are exactly the same.
+
+## Motivation
+
+Abseil promises no ABI stability, even from one day to the next. Two different
+source revisions of Abseil cannot be safely used in the same program. If two
+libraries in your program depend on Abseil, they must be built against the exact
+same version of Abseil, or things will break through violation of the One
+Definition Rule: loudly if you're lucky, or subtly if not. This “diamond
+dependency problem” is a common problem with all library code, and is why we
+recommend building all code in your project from source.
+
+However, while we discourage relying on compiled representations of libraries,
+we recognize this isn't always possible for providers of binaries or compiled
+libraries (such as package managers). This options mechanism is provided to
+allow those providers to ensure that copies of Abseil use the same
+implementation.
+
+## Caveats
+
+Two copies of Abseil configured with different options are incompatible, in
+exactly the same way that two different source snapshots of Abseil are
+incompatible. Abseil options must be set consistently across an entire program.
+They cannot be changed on a per-library basis.
+
+These options are dangerous if used incorrectly, and can only be safely used in
+some contexts.
+
+## Usage
+
+We have placed Abseil options in a common file,
+[`absl/base/options.h`][options-file]. The options file documents and enforces
+the feature selections used to build the Abseil library. Setting these flags on
+the command like (via a `-D` compiler flag, for instance) won't work: you must
+edit the `options.h` file directly, and distribute the patched `options.h` file,
+so that users are forced to compile their program with the same set of options
+that were used to build the pre-compiled library.
+
+A good rule of thumb is that it is safe to edit the options file only if you
+maintain the source of truth of Abseil for your build. Some examples of this:
+
+* You are using a Bazel WORKSPACE file to import Abseil and build from source,
+  and are using the `patches=` feature of the `http_archive()` rule to override
+  the options consistently. (See the [Bazel docs][bazel] for more information.)
+* You maintain a copy of Abseil in your source code repository which your
+  project builds against.
+* You are a binary package manager, and are installing Abseil headers on users’
+  systems.
+
+Because of the increased testing burden this imposes, we plan to keep the set of
+options we support small. If you change any options, we recommend that you run
+the Abseil unit tests, to ensure your settings work with your toolchain. The
+default options we ship with reflect how we use Abseil internally. This is the
+configuration that is “battle tested” in Google’s C++ codebase.
+
+[options-file]: https://github.com/abseil/abseil-cpp/blob/master/absl/base/options.h
+[bazel]: https://docs.bazel.build/versions/master/repo/http.html


### PR DESCRIPTION
Included changes:

280690817(Abseil Team):	Release absl::int128.
280687995(shreck):	        Publish options guide
280277001(shreck):	        Add an options guide, and update the release management guide
