### PR TITLE
Add missing semicolon after Frobber

### DIFF
--- a/_posts/2018-02-22-totw-61.md
+++ b/_posts/2018-02-22-totw-61.md
@@ -61,7 +61,7 @@ class Frobber {
   const char* ptr_;
   // length_ has a non-static class member initializer
   const size_t length_ = strlen(ptr_);
-}
+};
 ```
 
 This code is equivalent to the older code:
@@ -77,7 +77,7 @@ class Frobber {
  private:
   const char* ptr_;
   const size_t length_;
-}
+};
 ```
 
 Note that the first and second `Frobber` constructors have initializers for


### PR DESCRIPTION
The other class & struct definitions correctly have semicolons after them, however the Frobber class here doesn't seem to.