### PR TITLE
fix typo for Tip #108

### DIFF
--- a/_posts/2019-12-19-totw-108.md
+++ b/_posts/2019-12-19-totw-108.md
@@ -25,7 +25,7 @@ Using `std::bind()` correctly is hard. Let's look at a few examples. Does this
 code look good to you?
 
 ```c++
-void DoStuffAsync(std::function<void(Status)>; cb);
+void DoStuffAsync(std::function<void(Status)> cb);
 
 class MyClass {
   void Start() {


### PR DESCRIPTION
`void DoStuffAsync(std::function<void(Status)>; cb);` should be `void DoStuffAsync(std::function<void(Status)> cb);`