### PR TITLE
Correct spelling of EfficiOS.

### DIFF
--- a/_posts/2020-02-12-tcmalloc.md
+++ b/_posts/2020-02-12-tcmalloc.md
@@ -92,7 +92,7 @@ Our per-CPU caches take advantage of the fact that only one thread can run
 on a single core at any given time and that pre-emptions during the critical
 sequence of an allocation are relatively rare. These caches are based on the
 Linux kernel’s [restartable sequences (RSEQ)][rseq] feature, developed by
-Paul Turner and Andrew Hunter at Google and Mathieu Desnoyers at Efficios.
+Paul Turner and Andrew Hunter at Google and Mathieu Desnoyers at EfficiOS.
 Restartable sequences let us execute a region of code atomically and restart
 if we are interrupted by the kernel.
 


### PR DESCRIPTION
In the original, this was spelled "Efficios" (lower case).