### PR TITLE
Remove an invalid link to tip 116

### DIFF
--- a/_posts/2020-04-06-totw-177.md
+++ b/_posts/2020-04-06-totw-177.md
@@ -109,9 +109,7 @@ hold `const` or reference members, it's only a concern when those implementation
 decisions are constraining or corrupting the interface presented by that class.
 If you've already made a thoughtful and conscious decision that your type need
 not be copyable, it's very reasonable for you to make different choices about
-how to represent the data members of the class. (But see
-[Tip #116 for some](/tips/116 for some) more thoughts and pitfalls around
-argument lifetime and reference storage).
+how to represent the data members of the class.
 
 ## The Unusual Case: immutable types
 


### PR DESCRIPTION
TotW 116 was never published, so abseil.io shouldn't reference it.