### PR TITLE
Export of internal doc changes to Abseil OSS:

### DIFF
--- a/about/design/index.md
+++ b/about/design/index.md
@@ -22,3 +22,5 @@ be adding more design notes in the future.
 ## [`charconv`](charconv)
 
 ## [B-Tree Maps](btree)
+
+## [Random Library](random)

--- a/about/design/swisstables.md
+++ b/about/design/swisstables.md
@@ -41,7 +41,7 @@ value. We split this value up into two parts:
 
 For performance reasons, it is important that you use a hash function that
 distributes entropy across the entire bit space well (producing an
-[avalanche effect][avalanche]. The Abseil [hash framework][absl-hash]
+[avalanche effect][avalanche]). The Abseil [hash framework][absl-hash]
 accomplishes this well and should be sufficient for most users.
 
 <img src="images/hashbits-layout.png" align="center"
@@ -164,5 +164,5 @@ order) of
 
 [cppcon]: https://www.youtube.com/watch?v=ncHmEUmJZf4
 [avalanche]: https://en.wikipedia.org/wiki/Avalanche_effect
-[absl-hash]: /docs/cpp/guides/hash.md
+[absl-hash]: /docs/cpp/guides/hash
 [sse]: https://en.wikipedia.org/wiki/Streaming_SIMD_Extensions

--- a/docs/cpp/guides/container.md
+++ b/docs/cpp/guides/container.md
@@ -277,13 +277,13 @@ a key. In general, containers require the keys to be of a specific type, which
 can lead to inefficiencies at call sites that need to convert between
 near-equivalent types (such as `std::string` and `absl::string_view`).
 
-<pre class="bad-code">
+```cpp {.bad}
 std::map<std::string, int> m = ...;
 absl::string_view some_key = ...;
 // Construct a temporary `std::string` to do the query.
 // The allocation + copy + deallocation might dominate the find() call.
 auto it = m.find(std::string(some_key));
-</pre>
+```
 
 To avoid this unnecessary work, the Swiss tables provide heterogeneous lookup
 for conversions to string types (allowing `absl::string_view` in the lookup, for

--- a/docs/cpp/guides/flags.md
+++ b/docs/cpp/guides/flags.md
@@ -131,6 +131,8 @@ Flags defined with `ABSL_FLAG` will create global variables named
 <code>FLAGS_<i>name</i></code> of the specified type and default value. Help text
 will be displayed using the `--help` usage argument, if invoked.
 
+### Standard Flags
+
 Out of the box, the Abseil flags library supports the following types:
 
 * `bool`
@@ -144,11 +146,36 @@ Out of the box, the Abseil flags library supports the following types:
 * `double`
 * `std::string`
 * `std::vector<std::string>`
+* `absl::LogSeverity` (provided natively for layering reasons)
 
 NOTE: support for integral types is implemented using overloads for
 variable-width fundamental types (`short`, `int`, `long`, etc.). However,
 you should prefer the fixed-width integral types as noted above (`int32_t`,
 `uint64_t`, etc.)
+
+### Abseil Flags
+
+In addition, several Abseil libraries provide their own custom support for
+Abseil flags. Documentation for these formats is provided in the type's
+`AbslParseFlag()` definition.
+
+The Abseil [time library][time-library] provides the flag support for
+absolute time values:
+
+* `absl::Duration`
+* `absl::Time`
+
+The [civil-time library][civiltime-library] additionally provides flag support
+for the following civil-time values:
+
+* `absl::CivilSecond`
+* `absl::CivilMinute`
+* `absl::CivilHour`
+* `absl::CivilDay`
+* `absl::CivilMonth`
+* `absl::CivilYear`
+
+Additional support for Abseil types will be noted here as it is added.
 
 See [Defining Custom Flag Types](#custom) for how to provide support for a new
 type.
@@ -451,7 +478,7 @@ enum class OutputMode { kPlainText, kHtml };
 // AbslParseFlag converts from a string to OutputMode.
 // Must be in same namespace as OutputMode.
 
-// Parses an OutputMode from the command line flag value `text. Returns
+// Parses an OutputMode from the command line flag value `text`. Returns
 // `true` and sets `*mode` on success; returns `false` and sets `*error`
 // on failure.
 bool AbslParseFlag(absl::string_view text,
@@ -541,6 +568,9 @@ std::string AbslUnparseFlag(const MyFlagType& flag) {
 *   If you must declare `AbslParseFlag()` and `AbslUnparseFlag()` away from
     `T`'s declaration, you must still be the owner of `T` and must guarantee
     that the functions are defined exactly once in the codebase.
+*   Document the format string of the flag where you declare `AbslParseFlag()`
+    and `AbslUnparseFlag()`. As the owner of `T`, you are responsible for
+    documenting this format.
 *   `absl::StrSplit("")` returns `{""}` (a list with one element), so watch out
     for that if you are defining a compound flag type. Flags defined with
     `ABSL_FLAG(std::vector<std::string>, ...)` treat an empty string as an empty
@@ -556,3 +586,5 @@ std::string AbslUnparseFlag(const MyFlagType& flag) {
 
 [retired-flags]: https://abseil.io/tips/90
 [friend-functions]: http://en.cppreference.com/w/cpp/language/friend
+[time-library]: https://cs.corp.google.com/google3/third_party/absl/time/time.h
+[civiltime-library]: https://cs.corp.google.com/google3/third_party/absl/time/civil_time.h

--- a/docs/cpp/guides/meta.md
+++ b/docs/cpp/guides/meta.md
@@ -8,20 +8,19 @@ type: markdown
 # The Meta Library
 
 This `meta` library contains C++11-compatible versions of standard
-`<type_traits>` API functions for determining the characteristics of types. Such
-traits can support type inference, classification, and transformation, as well
-as make it easier to write templates based on generic type behavior.
+[`<type_traits>`][type_traits] API functions for determining the characteristics
+of types. Such traits can support type inference, classification, and
+transformation, as well as make it easier to write templates based on generic
+type behavior.
 
-See https://en.cppreference.com/w/cpp/header/type_traits
-
->WARNING: use of many of the constructs in this header will count as "complex
->template metaprogramming", so before proceeding, please carefully consider
->https://google.github.io/styleguide/cppguide.html#Template_metaprogramming
+> WARNING: use of many of the constructs in this header will count as "complex
+> template metaprogramming", so before proceeding, please carefully consider the
+> Style Guide's [advice on template metaprogramming][style-guide-templates].
 >
->Using template metaprogramming to detect or depend on API
->features is brittle and not guaranteed. Neither the standard library nor
->Abseil provides any guarantee that APIs are stable in the face of template
->metaprogramming. Use with caution.
+> Using template metaprogramming to detect or depend on API features is brittle
+> and not guaranteed. Neither the standard library nor Abseil provides any
+> guarantee that APIs are stable in the face of template metaprogramming. Use
+> with caution.
 
 ## Type Trait Usage
 
@@ -82,3 +81,6 @@ yield a type:
 * `absl::common_type_t`
 * `absl::underlying_type_t`
 * `absl::result_of_t`
+
+[type_traits]: https://en.cppreference.com/w/cpp/header/type_traits
+[style-guide-templates]: https://google.github.io/styleguide/cppguide.html#Template_metaprogramming

--- a/docs/cpp/guides/numeric.md
+++ b/docs/cpp/guides/numeric.md
@@ -20,15 +20,28 @@ some categories of conversion are explicit, as noted below.
 
 ### `uint128`
 
-The `uint128` type defines an unsigned 128-bit integer supporting the following:
+The `uint128` type represents an unsigned 128-bit integer. The API is meant to
+mimic an intrinsic integer type as closely as possible, so that any forthcoming
+`uint128_t` can be a drop-in replacement.
+
+The `uint128` type supports the following:
 
 *   Implicit conversion from integral types
-*   Explicit conversion to integral types
-*   Explicit conversion to and from floating point types
 *   Overloads for `std::numeric_limits`
 
+However, a `uint128` differs from intrinsic integral types in the following
+ways:
+
+* It is not implicitly convertible to other integral types, including other
+  128-bit integral types. Conversions must be explicit.
+* It requires explicit construction from and conversion to floating point types.
+* The type traits `std::is_integral<uint128>::value` and
+  `std::is_arithmetic<uint128>::value` are both `false`.
+
 Additionally, if your compiler supports the `__int128` type extension, `uint128`
-is interoperable with that type.
+is interoperable with that type, though `uint128` will not be a typedef in this
+case. (Abseil checks for this compatibility through the
+`ABSL_HAVE_INTRINSIC_INT128` macro.)
 
 128-bit integer literals are not yet a part of the C++ language. As a result, to
 construct a 128-bit unsigned integer with a value greater than or equal to 2^64,
@@ -58,17 +71,29 @@ uint64_t low = absl::Uint128Low64(v);
 
 ### `int128`
 
-The `int128` type defines a signed 128-bit integer supporting the following:
+The `int128` type defines a signed 128-bit integer. The API is meant to
+mimic an intrinsic integer type as closely as possible, so that any forthcoming
+`int128_t` can be a drop-in replacement.
+
+The `int128` type supports the following:
 
 *   Implicit conversion from signed integral types and unsigned types narrower
     than 128 bits
-*   Explicit conversion from unsigned 128-bit types
-*   Explicit conversion to integral types
-*   Explicit conversion to and from floating point types
 *   Overloads for `std::numeric_limits`
 
-Additionally, if your compiler supports the `__int128` type extension, `int128`
-is interoperable with that type.
+However, an `int128` differs from intrinsic integral types in the following
+ways:
+
+* It is not implicitly convertible to other integral types, including other
+  128-bit integral types. Conversions must be explicit.
+* It requires explicit construction from and conversion to floating point types.
+* The type traits `std::is_integral<int128>::value` and
+  `std::is_arithmetic<int128>::value` are both `false`.
+
+If your compiler supports the `__int128` type extension, `int128` is
+interoperable with that type, though `int128` will not be a typedef in this
+case. (Abseil checks for this compatibility through
+the `ABSL_HAVE_INTRINSIC_INT128` macro.)
 
 128-bit integer literals are not yet a part of the C++ language. As a result, to
 construct a 128-bit signed integer with a value greater than or equal to 2^64,

--- a/docs/cpp/guides/random.md
+++ b/docs/cpp/guides/random.md
@@ -226,6 +226,21 @@ contexts may introduce occasional (but dangerous) security issues. Although
 `absl::BitGen` is not suitable for cryptographic applications such as key
 generation, it provides guarantees strong enough to be resilient to misuse.
 
+### What About Instances Shared Across Multiple Threads?
+
+Like the C++ standard library random engines, neither `absl::BitGen`,
+nor `absl::InsecureBitGen` are thread safe.
+
+Efficiently leveraging a bit generator shared between multiple threads can be
+tricky and subtle. Use of locally-instantiated generators are preferred to
+global application-owned bit generators protected by a `Mutex` and shared across
+multiple threads.
+
+If your random sampling is happening on a hot path and you can afford a larger
+memory footprint, then consider further reducing compute costs by using a
+`thread_local absl::BitGen` for the lifetime of your process (but note that it
+must be inside a function). The usual subtleties of using `thread_local` apply.
+
 ### Can I Use Abseil's Distribution Functions With Other Bit Generator Types?
 
 Yes - the distribution functions are compatible with any type conforming to the

--- a/docs/cpp/guides/strings.md
+++ b/docs/cpp/guides/strings.md
@@ -479,7 +479,7 @@ Traditionally, most C++ code used built-in functions such as `sprintf()` and
 `absl::string_view` and the memory of the formatted buffer must be managed.
 
 ```cpp
-// Bad. Need to worry about buffer size and null-terminations.
+// Bad. Need to worry about buffer size and NUL-terminations.
 
 std::string GetErrorMessage(char *op, char *user, int id) {
   char buffer[50];
@@ -547,7 +547,7 @@ string at run-time, is slower than `absl::StrCat()`. Choose `Substitute()` over
 The Abseil strings library also contains simple utilities for performing string
 matching checks. All of their function parameters are specified as
 `absl::string_view`, meaning that these functions can accept `std::string`,
-`absl::string_view` or null-terminated C-style strings.
+`absl::string_view` or NUL-terminated C-style strings.
 
 ```cpp
 // Assume "msg" is a line from a logs entry

--- a/docs/cpp/guides/time.md
+++ b/docs/cpp/guides/time.md
@@ -43,11 +43,11 @@ fields represent the time as defined by some local government. Your civil time
 matches the values shown on the clock hanging on your wall and the Dilbert
 calendar on your desk. Your friend living across the country may, at the same
 moment, have a different civil time showing on their Far Side calendar and
-clock. For example, if you lived in New York on July 20, 1969 you witnessed Neil
-Armstrong's small step at 10:56 in the evening, whereas your friend in San
-Francisco saw the same thing at 7:56, and your pen pal in Sydney saw it while
-eating lunch at 12:56 on July 21. You all would agree on the absolute time of
-the event, but you'd disagree about the civil time.
+clock. For example, if you lived in New York, then you witnessed Neil
+Armstrong's small step on July 20, 1969 at 10:56 PM, whereas your friend in San
+Francisco saw the same thing at 7:56 PM, and your pen pal in Sydney saw it while
+eating lunch on July 21, 1969 at 12:56 PM. You all would agree on the absolute
+time of the event, but you'd disagree about the civil time.
 
 Time zones are geo-political regions within which rules are shared to convert
 between absolute times and civil times. The geographical nature of time zones is
@@ -189,7 +189,7 @@ absl::Time takeoff = absl::FromCivil(ct, nyc);
 
 Formatting and parsing functions are provided for converting to and from
 strings. `FormatTime()` allows you to take an absolute time and time zone and
-return a string representing that time. (See [Time Zones](#time-zones) below.)
+return a string representing that time. (See [Time Zones](#timezones) below.)
 
 ```cpp
 // Construct an absl::Time from the system clock.

--- a/docs/cpp/platforms/feature_checks.md
+++ b/docs/cpp/platforms/feature_checks.md
@@ -60,29 +60,36 @@ Note: `#if` and `#ifdef` have different results when a macro is defined to `0`.
 We explicitly state that a feature check macro should be undefined for a
 “false” state so both `#if` and `#ifdef` can be used interchangeably.
 
-When writing preprocessor conditionals, you can either whitelist all platforms
-where a given feature is available, or blacklist all platforms where a given
-feature is missing. Either option has pros and cons:
+When writing preprocessor conditionals, you can either opt into use of a feature
+by explicitly listing all platforms where a given feature is available, or opt
+out by explicitly listing all platforms where a given feature is missing or
+broken. Either option has pros and cons:
 
-|| whitelist |blacklist|
-|----|------------|----------|
-|pros|Generally safe, and more likely to build on a new platform.|The compilation fails if a new platform doesn’t support the feature.|
-|cons|The whitelist needs to be extended for each new platform.|Compilation might succeed but runtime behavior might be unexpected, if the interface exists but the implementation is problematic.|
+|      | opt-in                          | opt-out                             |
+| ---- | ------------------------------- | ----------------------------------- |
+| pros | Generally safe, and more likely | The compilation fails if a new      |
+:      : to build on a new platform.     : platform doesn’t support the        :
+:      :                                 : feature.                            :
+| cons | The allow-list needs to be      | Compilation might succeed but       |
+:      : extended for each new platform. : runtime behavior might be           :
+:      :                                 : unexpected, if the interface exists :
+:      :                                 : but the implementation is           :
+:      :                                 : problematic.                        :
 
-When choosing a whitelist or blacklist approach, think about what is likely to
-happen when a new platform is added and which approach is easier to maintain the
+When choosing a opt-in or opt-out approach, think about what is likely to happen
+when a new platform is added and which approach is easier to maintain the
 invariant of your module.
 
 Some examples:
 
 If you are working around a compiler bug or a missing C++ feature in the
-standard library implementation, you probably want to blacklist the combinations
+standard library implementation, you probably want to deny-list the combinations
 where the feature is missing. When a new platform is added, you can assume it is
 standards-compliant, and your unit test will fail if it is not.
 
 If you are relying on a low-level OS feature for better functionality (more
-logging, better debugging context), you probably want to white-list the
+logging, better debugging context), you probably want to allow-list the
 operating systems that claim to support this feature. When a new OS is added,
 you can assume the feature is missing, and your module will continue to work
 with minimum functionality. If desired, a developer can decide to opt-in by
-extending the whitelist.
+extending the allow-list.

--- a/docs/cpp/platforms/macros.md
+++ b/docs/cpp/platforms/macros.md
@@ -30,10 +30,9 @@ their own, separate guide.
 The macros that Abseil uses are listed below, in tables that list the
 macro, what it identifies, and what standard defines the macro.
 
-<p class="note">If you wish to check what macros your compiler has defined, see
-<a
-href="http://nadeausoftware.com/articles/2011/12/c_c_tip_how_list_compiler_predefined_macros">How
-to List Compiler Predefined Macros</a>.</p>
+<p class="note">If you wish to check what macros your platform has defined, see
+<a href="https://sourceforge.net/p/predef/wiki/Home/">Pre-defined Compiler
+Macros</a>.</p>
 
 ## Architecture
 
@@ -59,13 +58,13 @@ References:
 
 * [Architectures](https://sourceforge.net/p/predef/wiki/Architectures/)
   within the Sourceforge Pre-defined Compiler Macros guide.
-* [How to detect the processor type using compiler predefined macros](http://nadeausoftware.com/articles/2012/02/c_c_tip_how_detect_processor_type_using_compiler_predefined_macros)
+* [Pre-defined Compiler Macros](https://sourceforge.net/p/predef/wiki/Home/)
 
 ## Endianness
 
 No standard portable pre-defined macro exists that can be used to
 determine endianness. Instead, Abseil defines the following macros in
-`absl/base/config/h`:
+`absl/base/config.h`:
 
 * `ABSL_IS_LITTLE_ENDIAN`
 * `ABSL_IS_BIG_ENDIAN`
@@ -84,7 +83,7 @@ References:
 `_WIN32`      | Windows              | For both 32-bit and 64-bit environments
 `__linux__`   | Linux                | Android NDK, GNU C, Clang/LLVM
 `__ros__`     | Akaros               |
-`__Fuchsia__` | Fuchsia              |
+`__Fushsia__` | Fuchsia              |
 
 References:
 


### PR DESCRIPTION
rpc://team/absl-team/Abseil-Docs

Included changes:

318472990(shreck):	Add public documentation on StrFormat extensions
317925379(Abseil Team):	Inclusive language fix: Stop using blacklist/whitelist terminology in Abseil.
317681830(Abseil Team):	Update the Bazel quickstart guide so that it works andcontains more practical instructions.
314919304(Abseil Team):	Internal change.
311583161(Abseil Team):	Minor cleanup of naming and formatting in StrFormat's documentation.This makes the examples better match Google's C++ style guide.
310906247(Abseil Team):	Fix a couple raw URLs, which aren't linkified on abseil.io.
307606064(shreck):	Internal change
306929052(Abseil Team):	Add custom sink support for `absl::Format()` through an ADL extension mechanism.Users can now define`void AbslFormatFlush(MySink* dest, absl::string_view part)`to allow `absl::Format()` to append to a custom sink.
306912535(Abseil Team):	Fix broken links to pre-defined compiler macros
305039410(Abseil Team):	Add a missing close paren.
304902046(Abseil Team):	fix a bad code snippet.
302499045(shreck):	Add information on using ParsedFormat for advanced formatting, including C++17 bitwise-or operations
301817010(Abseil Team):	Internal change
301643758(Abseil Team):	Internal change
296480658(Abseil Team):	Update language and recommendations around thread-safety of absl::BitGen
295751508(Abseil Team):	Clarify the Armstrong date/time examples.
292606813(Abseil Team):	Typo-fix in the documentation.
290862964(Abseil Team):	Update internal documentation link.
289928010(shreck):	Specify Time library flag formats
289522777(Abseil Team):	Fix link to Hash framework documentation.
288359906(shreck):	Update developer docs on int128/uint128
285036610(shreck):	Change null-term* (and nul-term*) to NUL-term* in comments
281802685(shreck):	Add random design note to index file

PiperOrigin-RevId: 318472990
Change-Id: Idf5ae5b8e80d7f28d9afea4fea82a4bb2210dded