### PR TITLE
Fix anchor link to Deadlock Detection

### DIFF
--- a/docs/cpp/guides/synchronization.md
+++ b/docs/cpp/guides/synchronization.md
@@ -147,7 +147,7 @@ of `std::mutex` but adds the following additional features:
   acquired in a consistent order). The deadlock detector is enabled by default
   in most non-opt build modes, and it can detect deadlock risks that even Clang's
   [Thread Sanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html) misses.
-  (See [Deadlock Detection](#Deadlock-detection) below.)
+  (See [Deadlock Detection](#deadlock-detection) below.)
 
 Additionally, `absl::Mutex` can act as a reader-writer lock (like
 `std::shared_mutex`) with special `ReaderLock()` and `ReaderUnlock()` functions.


### PR DESCRIPTION
This fixes the link to heading "Deadlock Detection". As shown in attached screenshots, while the value of the id attribute is "deadlock-detection" in the h4 element, "Deadlock-detection" is used when it is linked.

<img width="1479" alt="Screen Shot 2020-09-03 at 13 59 26" src="https://user-images.githubusercontent.com/1183444/92087189-2f5c1600-ee06-11ea-8e33-11492836d3bb.png">

<img width="1300" src="https://user-images.githubusercontent.com/1183444/92087760-e2c50a80-ee06-11ea-93af-651b642cf161.png">
