### PR TITLE
minor: Variable `s` doesn’t exist in snippet.

### DIFF
--- a/docs/cpp/guides/status.md
+++ b/docs/cpp/guides/status.md
@@ -131,7 +131,7 @@ absl::Status my_status = DoSomething();
 //
 // Use the Status.ok() helper function:
 if (!my_status.ok()) {
-  LOG(WARNING) << "Unexpected error " << s;
+  LOG(WARNING) << "Unexpected error " << my_status;
 }
 ```
 


### PR DESCRIPTION
Variable `s` doesn’t exist in snippet. 

Probably the correct variable name is `my_status`.

Sorry for the tiny PR.