### PR TITLE
Replace internal links

### DIFF
--- a/docs/cpp/guides/flags.md
+++ b/docs/cpp/guides/flags.md
@@ -587,5 +587,5 @@ std::string AbslUnparseFlag(const MyFlagType& flag) {
 
 [retired-flags]: https://abseil.io/tips/90
 [friend-functions]: http://en.cppreference.com/w/cpp/language/friend
-[time-library]: https://cs.corp.google.com/google3/third_party/absl/time/time.h
-[civiltime-library]: https://cs.corp.google.com/google3/third_party/absl/time/civil_time.h
+[time-library]: time.md#time-durations
+[civiltime-library]: time.md#civil-times


### PR DESCRIPTION
Replaces internal documentation links (https://cs.corp.google.com/...) with links to public Abseil documentation.

```
$ grep -r "corp.google" .
./docs/cpp/guides/flags.md:[time-library]: https://cs.corp.google.com/google3/third_party/absl/time/time.h
./docs/cpp/guides/flags.md:[civiltime-library]: https://cs.corp.google.com/google3/third_party/absl/time/civil_time.h
```