### PR TITLE
Typo __Fushsia__

### DIFF
--- a/docs/cpp/platforms/macros.md
+++ b/docs/cpp/platforms/macros.md
@@ -83,7 +83,7 @@ References:
 `_WIN32`      | Windows              | For both 32-bit and 64-bit environments
 `__linux__`   | Linux                | Android NDK, GNU C, Clang/LLVM
 `__ros__`     | Akaros               |
-`__Fushsia__` | Fuchsia              |
+`__Fuchsia__` | Fuchsia              |
 
 References:
 


### PR DESCRIPTION
`__Fushsia__` should be `__Fuchsia__`.