### PR TITLE
Documentation Push 1/5/2021

### DIFF
--- a/about/releases.md
+++ b/about/releases.md
@@ -41,10 +41,9 @@ branch of Abseil instead.
 
 ## Obtaining an LTS Branch
 
-The set of LTS branches of Abseil is available on our
-[Long Term Support (LTS) Branches][LTS] page. As LTS branches are added to
-this page, entries will be added to the list. We will also list any critical
-fixes to specific LTS branches on this page.
+The set of LTS branches of Abseil is available on our [GitHub releases
+page](https://github.com/abseil/abseil-cpp/releases). Critical fixes to specific
+LTS branches will be published on this page.
 
 ## Options for Using Abseil Code In Your Source Code or Binary
 
@@ -106,4 +105,3 @@ between different builds of Abseil.)
   our [Compatibility Guidelines](compatibility) when in
   doubt.
 
-[LTS]: https://github.com/abseil/abseil-cpp/blob/master/LTS.md

--- a/docs/cpp/guides/status.md
+++ b/docs/cpp/guides/status.md
@@ -83,8 +83,8 @@ A non-OK Status typically includes both an error code
 file.txt filename is missing"). The API provides `code()` and `message()` member
 functions to retrieve these values. The error code is intended for programs to
 examine (e.g., the caller might react differently based on the error code it
-sees). The message is not intended for end users; it may get logged somewhere
-for a developer or SRE to examine and find out what went wrong.
+sees). The error message may be logged somewhere for a developer or SRE to
+examine and find out what went wrong. The message is not intended for end users.
 
 NOTE: low-level routines such as a file `Open()` operation should typically not
 log status values themselves, but should pass them up to the caller who will
@@ -188,7 +188,7 @@ the `absl::StatusOr<T>` holds an object of type `T`:
 
 ```c++
 absl::StatusOr<int> i = GetCount();
-if (foo.ok()) {
+if (i.ok()) {
   updated_total += *i
 }
 ```

--- a/docs/cpp/platforms/macros.md
+++ b/docs/cpp/platforms/macros.md
@@ -43,6 +43,7 @@ Macros</a>.</p>
 |`__arm__`|ARM||32-bit only|
 |`_M_ARM`|ARM|Visual Studio||
 |`__aarch64__`|ARM64|||
+|`_M_ARM64`|ARM64|Visual Studio||
 |`__i386__`|Intel x86|||
 |`_M_IX86`|Intel x86|Visual Studio\*||
 |`__ia64__`|Intel Itanum (IA-64)|||

--- a/docs/cpp/platforms/platforms.md
+++ b/docs/cpp/platforms/platforms.md
@@ -7,59 +7,44 @@ type: markdown
 
 # Abseil Platforms
 
-The Abseil C++ code is supported on the following platforms. By "platforms",
-we mean the union of operating system, architecture (e.g. little-endian vs.
-big-endian), compiler, and standard library.
+The Abseil C++ code is supported on the following platforms. By "platforms", we
+mean the union of operating system, architecture (e.g. CPU, little-endian vs.
+big-endian, etc.), compiler, and standard library.
 
 ## Support Levels
 
 Abseil has two basic levels of support:
 
 <ul>
-  <li><b>Supported</b> means that the indicated platform is officially
-  supported. We pledge to test our code on that platform, have automated
-  continuous integration (CI) tests for that platform, and bugs within that
-  platform will be treated with high priority.</li>
+  <li><b>Supported</b> means that Abseil is expected to work on the indicated
+  platform, and it will be considered a bug if Abseil stops working. We pledge
+  to test our code on that platform, have automated continuous integration (CI)
+  tests for that platform, and bugs within that platform will be treated with
+  high priority.</li>
   <li><b>Best Effort</b> means that we may or may not run continuous integration
   tests on the platform, but we are fairly confident that Abseil should work on
   the platform. Although we may not prioritize bugs on the associated platforms,
   we will make our best effort to support it, and we will welcome patches based
-  on this platform. We may at some point officially support such a
-  platform.</li>
+  on this platform. We may at some point officially support such a platform.</li>
 </ul>
 
 Any other platform that is not explicitly mentioned as **Supported** or
-**Best Effort** is *not supported*. We will not accept patches for such
-platforms and we will not prioritize bugs related to such platforms.
+**Best Effort** is *not supported*. We may not prioritize bugs related to such
+platforms, and we will only accept patches that in our judgement do not
+complicate the code.
 
 ## C++11 and Above
 
 Abseil requires a code base that at least supports C++11 and our code is
 C++11-compliant. Often, we include C++11 versions of standard library
-functionality available in a later version (e.g C++14 and C++17). Many of these
-C++11 utlities will silently revert to their official standard library
-functionality when compiled on C++14 and C++17
-platforms. That is, we guarantee that our code will compile under any of the
-following compilation flags:
+functionality available in a later version (e.g C++14 through C++20). Many of
+these C++11 utlities will silently revert to their official standard library
+functionality when compiled on C++14 or newer platforms. That is, we guarantee
+that our code will compile under any of the following compilation flags:
 
-Linux:
-
-* gcc, clang: `-std=c++11`
-* gcc, clang: `-std=c++14`
-* clang < 5.0: `-std=c++1z`
-* gcc, clang 5.0+: `-std=c++17`
-
-macOS:
-
-* gcc, clang: `-std=c++11`
-* gcc, clang: `-std=c++14`
-* clang < 5.0: `-std=c++1z`
-* gcc, clang 5.0+: `-std=c++17`
-
-Windows:
-
-* msvc: `/std:c++14`
-* msvc: `/std:c++latest`
+* GCC: `-std=c++11`, `-std=c++14`, `-std=c++17`, `-std=c++20`
+* Clang: `-std=c++11`, `-std=c++14`, `-std=c++17`, `-std=c++20`
+* MSVC: `/std:c++14`, `/std:c++17`
 
 ## Supported Platforms
 
@@ -180,8 +165,8 @@ themselves.
     </tr>
     <tr>
       <td>Windows, little-endian, 32/64-bit</td>
-      <td>MVC 2015 Update 3, MSVC 2017</td>
-      <td>msvc</td>
+      <td>MSVC 2015 Update 3, MSVC 2017</td>
+      <td>[MS STL](https://github.com/microsoft/STL)</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
48812591(Abseil Team):	Internal change
348530308(Abseil Team):	Point the link to LTS versions at the GitHub releases page, which will always be up-to-date.
348518028(Abseil Team):	Tweaks for better AArch64 support under MSVC
348511208(Abseil Team):	Update platform support guide
346870655(Abseil Team):	Correct if statement to use "i" instead of "foo" in an example.
344178514(Abseil Team):	The original version said that the status code is for programs, and the status message is not for users. Rephrase to clarify what the audience for the status message is: developers/SREs and not end-users.