### PR TITLE
Abseil Docs push: December 16

### DIFF
--- a/docs/cpp/guides/flags.md
+++ b/docs/cpp/guides/flags.md
@@ -152,7 +152,7 @@ Out of the box, the Abseil flags library supports the following types:
 NOTE: support for integral types is implemented using overloads for
 variable-width fundamental types (`short`, `int`, `long`, etc.). However, you
 should prefer the fixed-width integral types listed above (`int32_t`,
-`uint64_t`, etc.). -->
+`uint64_t`, etc.).
 
 ### Abseil Flags
 
@@ -217,8 +217,8 @@ was defined earlier in the same `.cc` file. If it wasn't, you'll get an
 
 If you need to allow other modules to access the flag, you must export it in
 some header file that is included by those modules. For an `ABSL_FLAG` flag
-named `FLAGS_name` of type `T`, use the `ABSL_DECLARE_FLAG(T, name);` macro to
-do so:
+named `FLAGS_name` of type `T`, use the `ABSL_DECLARE_FLAG(T, name);` macro
+defined in `absl/flags/declare.h` to do so:
 
 ```cpp
 ABSL_DECLARE_FLAG(absl::Duration, timeout);

--- a/docs/cpp/guides/format.md
+++ b/docs/cpp/guides/format.md
@@ -370,6 +370,14 @@ The `str_format` library provides customization utilities for formatting
 user-defined types using `StrFormat()`. As with most type extensions, you should
 own the type you wish to extend.
 
+> Tip: For types you don't own you can use `absl::FormatStreamed()` to format
+> types that have an `operator<<` but no intrinsic type support within
+> `StrFormat()`.
+>
+> ```cpp
+> absl::PrintF("My Foo: %s\n", absl::FormatStreamed(foo));
+> ```
+
 To extend formatting to your custom type, provide an `AbslFormatConvert()`
 overload as a free (non-member) function within the same file and namespace of
 that type, usually as a `friend` definition. The `str_format` library will check

--- a/docs/cpp/quickstart-cmake.md
+++ b/docs/cpp/quickstart-cmake.md
@@ -51,7 +51,7 @@ Navigate into this directory and run all tests:
 ```
 $ cd abseil-cpp
 $ mkdir build && cd build
-$ cmake -DBUILD_TESTING=ON -DABSL_USE_GOOGLETEST_HEAD=ON -DCMAKE_CXX_STANDARD=11 ..
+$ cmake -DABSL_BUILD_TESTING=ON -DABSL_USE_GOOGLETEST_HEAD=ON -DCMAKE_CXX_STANDARD=11 ..
 ...
 -- Configuring done
 -- Generating done


### PR DESCRIPTION
Included changes:

416030065(Abseil Team):	Update CMake quickstart to reflect BUILD_TESTING is now ABSL_BUILD_TESTING
407613257(Abseil Team):	Add a pointer to absl::FormatStreamed() from go/strformat.
407326908(Abseil Team):	End of HTML comment remained in the text.
405901779(Abseil Team):	Clarify the location of ABSL_DECLARE_FLAG macro.