### PR TITLE
Remove comment about speed from TotW 61 (Default Member Initializers)

### DIFF
--- a/_posts/2018-02-22-totw-61.md
+++ b/_posts/2018-02-22-totw-61.md
@@ -99,9 +99,8 @@ data member initializers, abbreviated to NSDMIs.
 
 ## Conclusion
 
-Default member initializers won’t make your program any faster. They will help
-reduce bugs from omissions, especially when someone adds a new constructor or a
-new data member.
+Default member initializers will help reduce bugs from omissions, especially when
+someone adds a new constructor or a new data member.
 
 Be careful not to confuse a non-static class member initializer with a static
 class member initializer:


### PR DESCRIPTION
It feels like a bummer, to start the Conclusion by saying that such initializers "won't make your program any faster". If that would really be an important conclusion of TotW 61, the main text of the item should elaborate on this aspect. Otherwise, it should not be part of the take-home message.