### PR TITLE
Remove line-height inline style for list items

### DIFF
--- a/fast/index.md
+++ b/fast/index.md
@@ -50,7 +50,7 @@ below in the order of re-publication.**
         <li><b>{{post.date | date: '%B %d, %Y' }}</b></li>
         {% assign datelist = datelist | append: cur_date %}
       {% endunless %}
-        <p style="text-indent:25px;line-height:5px;">
+        <p style="text-indent:25px;">
         <a href="{{ post.url }}">{{ post.title }}</a>
         </p>
     {% endif %}

--- a/tips/index.md
+++ b/tips/index.md
@@ -53,7 +53,7 @@ below in the order of re-publication.**
         <li><b>{{post.date | date: '%B %d, %Y' }}</b></li>
         {% assign datelist = datelist | append: cur_date %}
       {% endunless %}
-        <p style="text-indent:25px;line-height:5px;">
+        <p style="text-indent:25px;">
         <a href="{{ post.url }}">{{ post.title }}</a>
         </p>
     {% endif %}


### PR DESCRIPTION
This causes text to overlap when lines are long, as they are on mobile or when the window is narrow.

Fixes #429