### PR TITLE
Abseil Docs Push for Week of April 17, 2023

### DIFF
--- a/_posts/2017-09-26-totw-1.md
+++ b/_posts/2017-09-26-totw-1.md
@@ -96,9 +96,12 @@ storage is often questionable: you need some proof that the underlying data will
 outlive the `string_view`.
 
 If your API only needs to reference the string data during a single call, and
-doesn't need to modify the data, accepting a `string_view` is sufficient. If you
-need to reference the data later or need to modify the data, you can explicitly
-convert to a C++ string object using `std::string(my_string_view)`.
+doesn't need to modify the data, accepting a `string_view` is sufficient.
+
+If you need to use the data later or modify the data, you can explicitly convert
+to a C++ string object using `std::string(my_string_view)`. Another option,
+discussed in [Tip #117](/tips/117), is to pass a `std::string` by value and use
+`std::move` in callers when applicable.
 
 Adding `string_view` into an existing codebase is not always the right answer:
 changing parameters to pass by `string_view` can be inefficient if those are

--- a/_posts/2018-09-28-totw-144.md
+++ b/_posts/2018-09-28-totw-144.md
@@ -120,10 +120,10 @@ auto it = threads.find(id);
 
 ## STL Container Support and Alternatives
 
-Ordered containers (`std::{map,set,multimap,multiset}`) support heterogeneous
-lookup starting in `C++14`. As of `C++17`, unordered containers still do not
-support it. There are proposals for adding this feature, but none have been
-accepted yet.
+The standard ordered containers (`std::{map,set,multimap,multiset}`) support
+heterogeneous lookup. The standard *unordered* containers
+(`std::unordered_{map,set,multimap,multiset}`) do not support heterogeneous
+lookup until `C++20`.
 
 The new family of [Swiss Tables][swisstables], however, support heterogeneous
 lookup for both string-like types (`std::string`, `absl::string_view`, etc.) and

--- a/_posts/2023-01-19-totw-218.md
+++ b/_posts/2023-01-19-totw-218.md
@@ -1,0 +1,241 @@
+---
+title: "Tip of the Week #218: Designing Extension Points With FTADLE"
+layout: tips
+sidenav: side-nav-tips.html
+published: true
+permalink: tips/218
+type: markdown
+order: "218"
+---
+
+Originally posted as TotW #218 on January 19, 2023
+
+*By [Andy Soffer](mailto:asoffer@google.com)*
+
+Updated 2023-01-19
+
+Quicklink: [abseil.io/tips/218](https://abseil.io/tips/218)
+
+
+*Ftadle. It's a perfectly cromulent word. ~ Unknown*
+
+## Designing Extension Points
+
+Suppose you work on a library called `sketchy`, that draws on a canvas. You
+already provide ways to draw some common things like points, lines, and text,
+but you want to provide a mechanism where users can specify how to draw their
+own types. You're designing an **extension point**.
+
+### Design Goals For Extension Points
+
+C++ provides many mechanisms for defining extension points, each with their own
+benefits and drawbacks. When defining an extension point in C++ there are
+several considerations worth weighing:
+
+*   Readability -- How easy is it for an engineer to understand the relationship
+    between your library and the extension?
+
+*   Maintainability -- How easy will it be change the extension point as the
+    needs of your library and your library's users change?
+
+*   Dependency Hygiene -- Does your extension point require your library to be
+    linked in to a user's binary? We want to make sure extension points play
+    nicely with
+    [IWYU](https://google.github.io/styleguide/cppguide.html#Include_What_You_Use),
+    so if a header needs to be included for the extension mechanism to work, the
+    extended types should actually use something from that header.
+
+*   Lack of [ODR violations](http://go/odr-violation) -- Some mechanisms make it
+    easy to have different portions of your program have contradictory views
+    about what a program means. ODR violations are always a bug.
+
+### FTADLE: A Good Pattern With A Great Name
+
+When defining an extension point, we recommend following a pattern that we
+lovingly call *FTADLE[^1] (Friend Template
+[ADL](https://en.cppreference.com/w/cpp/language/adl) Extension)*. FTADLE does
+well on each of the considerations listed above. It relies heavily on a language
+feature known as ADL, or Argument Dependent Lookup; the process by which the
+compiler determines what function is intended when a function call appears
+without namespace qualification (i.e., no `::`s). ADL is explained in detail in
+[Tip #49](/tips/49), To write an extension using the FTADLE pattern:
+
+1.  Pick a name for your extension point and prefix it with your project's
+    namespace. Our extension is for drawing, and our project lives in the
+    `sketchy` namespace, so we'll call our extension `SketchyDraw`.
+
+1.  Design a type to be passed in to `SketchyDraw` that has all the behavior
+    your users will need. In our case, this is the `sketchy::Canvas` on which
+    users can draw their types.
+
+1.  Implement your functionality as an overload set. One member of that overload
+    set will be a template and will call your extension point. The non-template
+    functions in the overload set should be the basic building blocks; the
+    primitive types that your API supports. In our running example, that means
+    functions that accept the types `sketchy::Point` and `sketchy::Line`.
+
+    <pre class="prettyprint lang-cpp code">
+    namespace sketchy {
+    // Draws the point `p` on the canvas `c`.
+    void Draw(Canvas& c, const Point& p);
+
+    // Draws the line segment `l` on the canvas `c`.
+    void Draw(Canvas& c, const Line& l);
+
+    // For any user-defined type `T` which implements `SketchyDraw` (see
+    // documentation that I've definitely written), draws `value` on the canvas
+    // `c`.
+    template &lt;typename T&gt;
+    void Draw(Canvas& c, const T& value) {
+      // Called without namespace qualifiers. We rely on ADL to find the correct
+      // overload. See [Tip #49]([Tip #49](/tips/49)) for details on ADL.
+      SketchyDraw(c, value);
+    }
+
+    }  // namespace sketchy
+    </pre>
+
+With this extension-point designed, users will now be able to make their types
+drawable. How can an unrelated type add this `Draw` functionality without adding
+an explicit dependency? We can make use of a friend function to do so. By adding
+a friend function template in their type named `SketchyDraw` with the
+appropriate signature. the template overload above will use ADL to find the
+`SketchyDraw` function. For example,
+
+</pre>
+class Triangle {
+ public:
+  explicit Triangle(Point a, Point b, Point c) : a_(a), b_(b), c_(c) {}
+
+template &lt;typename SC&gt; friend void SketchyDraw(SC& canvas, const Triangle&
+triangle) { // Note: This is a template, even though the only type we ever
+expect to be // passed in for `SC` is `sketchy::Canvas`. Using `sketchy::Canvas`
+directly // works, but pulls in an extra dependency that may not be used by all
+users // of `Triangle`. sketchy::Draw(canvas, sketchy::Line(triangle.a_,
+triangle.b_)); sketchy::Draw(canvas, sketchy::Line(triangle.b_, triangle.c_));
+sketchy::Draw(canvas, sketchy::Line(triangle.c_, triangle.a_)); }
+
+private: Point a_, b_, c_; };
+
+// Usage:
+void DrawTriangles(sketchy::Canvas& canvas, absl::Span&lt;const Triangle&gt; triangles) {
+  for (const Triangle& triangle : triangles) {
+    sketchy::Draw(canvas, triangle);
+  }
+}
+</pre>
+
+NOTE: Users of the library never call the ADL extension point `SketchyDraw`
+directly. Rather, the library should provide a function like `sketchy::Draw`
+which invokes the extension point on the user's behalf.
+
+## Other Examples
+
+The FTADLE pattern has been used with several other common libraries.
+
+*   The `AbslHashValue` extension point allows you to make your type hashable by
+    any of Abseil's hash containers. See [Tip #152](/tips/152) for details.
+
+*   The `AbslStringify` extension point allows you to print your type with many
+    many Abseil libraries, including logging, `absl::StrCat`, `absl::StrFormat`,
+    and `absl::Substitute`.
+
+## What To Avoid
+
+Some common extension point mechanisms fall short of our design goals. Virtual
+functions, checking at compile-time for member functions, and template
+specialization are each brittle in their own way, as discussed below.
+
+### Virtual Functions
+
+Though perhaps the most familiar, virtual functions and class hierarchies are
+often overly rigid. They are nearly impossible to refactor, because the base
+class and all derived classes need to be updated in lock-step. We rarely get
+designs right on the first try, so it's prudent to have a design that we can
+change later.
+
+Beyond the rigidity, class hierarchies *force* a dependency on your users. In
+the case of `sketchy`, users are required to depend on `sketchy` code, even when
+only some of their binaries want to use the dependency. FTADLE ensures that only
+binaries that need to do something `sketchy` pay that cost.
+
+The same is true for non-template friend extension points as well (for example
+`std::ostream`'s `operator<<`). Each class that wishes to implement `operator<<`
+must include one of the standard library headers defining `std::ostream` (e.g.,
+`<ostream>`, `<iostream>`). This means that (barring optimizations) the code for
+`std::ostream` will be compiled and linked into the binary whether or not
+`operator<<` is used, a potential extra cost to compile-times and binary size.
+
+### Member Functions
+
+With some template trickery, you could check to see if a class has a particular
+method by name (or even signature). However, names can be misleading.
+
+<pre class="prettyprint lang-cpp bad-code">
+// Requires that the image have a `draw()` member function.
+template &lt;typename Image&gt;
+void DisplayImage(const Image& image) {
+  image.draw();
+}
+
+class Cowboy {
+ public:
+  // Draws the gun from the holster.
+  void draw();
+};
+
+int main() {
+  Cowboy c;
+  DisplayImage(c);  // Oops, not the "draw" we meant.
+}
+</pre>
+
+With the FTADLE pattern, the extension point is prefixed with the project's
+namespace, mitigating accidental conformance.
+
+### Template Specializations
+
+Another common but dangerous technique is to use template specializations. This
+is how `std::hash` and `std::less` are specialized.
+
+<pre class="prettyprint lang-cpp bad-code">
+namespace std {
+
+template&lt;&gt;
+struct hash&lt;MyType&gt; {
+  size_t operator()(const MyType& m) const {
+    return HashCombine(std::hash&lt;&gt;()(m.foo()), std::hash&lt;&gt;()(m.bar()));
+  }
+};
+
+}  // namespace std
+</pre>
+
+Aside from requiring more boilerplate, this technique is ripe for
+[ODR violations](http://go/odr-violation). While not terribly common, providing
+different specializations for this type in different translation units, or even
+the same definition twice is an ODR violation. More commonly, if such a
+specialization is available only in some translation units but not others,
+metaprogramming techniques will produce different answers to the question "is
+there a hash function available?" which is also an ODR-violation.
+
+Beyond that, it is generally bad practice to open up a namespace you do not own
+(amongst other reasons, because it leads to ODR violations). We should design
+our APIs to avoid bad practices so as not to accidentally encourage dangerous
+practices.
+
+## Conclusion
+
+The FTADLE extension point pattern is readable, maintainable, mitigates against
+ODR violations, and avoids adding dependencies. If your library needs an
+extension point, FTADLE comes highly recommended.
+
+[^1]: C++ has a rich tradition of almost-pronouncable
+    [acronyms](https://en.cppreference.com/w/cpp/language/acronyms), including
+    [RAII](https://en.cppreference.com/w/cpp/language/raii),
+    [IFNDR](https://en.cppreference.com/w/cpp/language/ndr),
+    [CRTP](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern),
+    and [SFINAE](https://en.cppreference.com/w/cpp/language/sfinae). We have
+    been pronouncing FTADLE as "fftah-dill" (similar to "battle" but with the
+    'b' replaced by the sound at the end of "raft"), but we encourage you to
+    pronounce it in whichever way brings you the most joy.

--- a/_posts/2023-02-15-totw-198.md
+++ b/_posts/2023-02-15-totw-198.md
@@ -1,0 +1,195 @@
+---
+title: "Tip of the Week #198: Tag Types"
+layout: tips
+sidenav: side-nav-tips.html
+published: true
+permalink: tips/198
+type: markdown
+order: "198"
+---
+
+Originally posted as TotW #198 on August 12, 2021
+
+*By [Alex Konradi](mailto:akonradi@google.com)*
+
+Updated 2022-01-24
+
+Quicklink: [abseil.io/tips/198](https://abseil.io/tips/198)
+
+
+Suppose we have a class `Foo`:
+
+<pre class="prettyprint lang-cpp code">
+class Foo {
+ public:
+  explicit Foo(int x, int y);
+  Foo& operator=(const Foo&) = delete;
+  Foo(const Foo&) = delete;
+};
+</pre>
+
+`Foo` is neither movable nor copyable, but it is constructible, e.g. `Foo f(1,
+2);`. Since it has a public constructor, we can easily make an instance wrapped
+in a `std::optional`:
+
+<pre class="prettyprint lang-cpp code">
+std::optional&lt;Foo&gt; maybe_foo;
+maybe_foo.emplace(5, 10);
+</pre>
+
+That's great, but what if the `std::optional` is declared `const`, so we can't
+call `emplace()`? Luckily for us, `std::optional` has a constructor for this:
+
+<pre class="prettyprint lang-cpp code">
+// Pass std::in_place as the first argument, followed by the arguments for Foo's
+// constructor.
+const std::optional&lt;Foo&gt; maybe_foo(std::in_place, 5, 10);
+</pre>
+
+Wait, what's going on with `std::in_place`? If we look at
+[the documentation](https://en.cppreference.com/w/cpp/utility/optional/optional)
+for `std::optional` construction, we can see that one of the overloads takes a
+`std::in_place_t` as the first argument, along with a list of additional
+arguments. Since
+[`std::in_place`](https://en.cppreference.com/w/cpp/utility/in_place) is an
+instance of `std::in_place_t`, the compiler chooses the *emplacing constructor*,
+which instantiates `Foo` within the `std::optional` by forwarding the rest of
+the arguments to `Foo`'s constructor.
+
+If we look a little closer at the documentation for `std::in_place_t`, we see
+that it's... an empty struct. No special qualifiers or magic declarations. The
+only thing even mildly special about it is that the standard library includes a
+named instance of it, `std::in_place`.
+
+## Overload Resolution Via Tag Types
+
+`std::in_place_t` is a member of a loose category of classes sometimes referred
+to as "tag types". The function of these classes is to pass information to the
+compiler by "tagging" specific overloads in an overload set. By providing an
+instance of an appropriate tag class to an overloaded function (often a
+constructor), we can use the compiler's ordinary resolution rules to make it
+select the desired overload. In the case of our `std::optional` construction,
+the compiler sees that the first argument is of type `std::in_place_t` and so
+chooses the matching emplacing constructor.
+
+Though `std::in_place_t` was introduced in C++17, the use of empty classes for
+tagging overloads in the standard library has been prevalent since
+[`std::piecewise_construct_t`](https://en.cppreference.com/w/cpp/utility/piecewise_construct_t),
+was introduced in C++11 to select the emplacing constructor for `std::pair`.
+C++17 significantly expanded the set of tag types in the standard library.
+
+## Templates, of Course
+
+Besides disambiguating overloads, another common use case for tag types is to
+pass type information to templated constructors. Consider these two structs:
+
+<pre class="prettyprint lang-cpp code">
+struct A { A(); /* internal members */ };
+struct B { B(); /* internal members */ };
+</pre>
+
+Let's try to construct an instance of
+[`std::variant<A, B>`](https://en.cppreference.com/w/cpp/utility/variant) with
+each:
+
+<pre class="prettyprint lang-cpp bad-code">
+// These work if A and B are copy- or move-constructible, but incur the
+// performance cost of an extra copy or move construction.
+std::variant&lt;A, B&gt; with_a{A()};
+std::variant&lt;A, B&gt; with_b{B()};
+
+// These aren't valid C++; the language doesn't support providing constructor
+// template parameters explicitly.
+std::variant&lt;A, B&gt; try_templating_a&lt;A&gt;{};
+std::variant&lt;A, B&gt;&lt;B&gt; try_templating_b{};
+</pre>
+
+What we need is a way to tell the `std::variant` constructor that we want to
+instantiate `A` or `B` without actually providing an instance of either. For
+that, we can use
+[`std::in_place_type`](https://en.cppreference.com/w/cpp/utility/in_place)!
+
+<pre class="prettyprint lang-cpp code">
+std::variant&lt;A, B&gt; with_a{std::in_place_type&lt;A&gt;};
+std::variant&lt;A, B&gt; with_b{std::in_place_type&lt;B&gt;};
+</pre>
+
+`std::in_place_type<T>` is an instance of the class template
+`std::in_place_type_t<T>`, which is (unsurprisingly, at this point) empty. By
+passing a value of type `std::in_place_type_t<A>` to `std::variant`'s
+constructor, the compiler can deduce that the constructor template parameter is
+our class `A`.
+
+## Usage
+
+Tag types show up occasionally when interacting with generic class templates,
+especially ones from the standard library. One of the shortcomings of tag types
+is that other techniques, such as factory functions, often result in more
+readable code. Take the following example:
+
+<pre class="prettyprint lang-cpp code">
+// This tag spelling requires the reader to know how std::optional interacts
+// with std::in_place.
+std::optional&lt;Foo&gt; with_tag(std::in_place, 5, 10);
+
+// Here the intent is clearer: make an optional Foo by providing these argments.
+std::optional&lt;Foo&gt; with_factory = std::make_optional&lt;Foo&gt;(5, 10);
+</pre>
+
+These two `std::optional<Foo>` objects are guaranteed to be constructed
+identically thanks to C++17's [mandatory copy elision](/tips/166).
+
+So why use tags? Because factory functions don't always work:
+
+<pre class="prettyprint lang-cpp bad-code">
+// This doesn't work because Foo isn't move-constructible.
+std::optional&lt;std::optional&lt;Foo&gt;&gt; foo(std::make_optional&lt;Foo&gt;(5, 10));
+</pre>
+
+The above example doesn't compile because `Foo`'s move constructor is deleted.
+To make this work, we use `std::in_place` to select the `std::optional`
+constructor that forwards the remaining arguments.
+
+<pre class="prettyprint lang-cpp code">
+// This constructs everything in place, resulting in a single call to Foo's
+// constructor.
+std::optional&lt;std::optional&lt;Foo&gt;&gt; foo(std::in_place, std::in_place, 5, 10);
+</pre>
+
+In addition to working in places where factory functions don't, tag types have
+some other nice properties:
+
+-   they are
+    [literal types](https://en.cppreference.com/w/cpp/named_req/LiteralType)
+    which means we can declare `constexpr` instances, even in header files, like
+    `std::in_place`;
+-   because they are empty, the compiler can optimize them out, resulting in
+    zero runtime overhead.
+
+Though they're used in the standard library, encountering empty tag types in the
+wild is relatively uncommon. If you find yourself using one, consider adding a
+comment to help your readers:
+
+<pre class="prettyprint lang-cpp code">
+std::unordered_map&lt;int, Foo&gt; int_to_foo;
+// std::piecewise_construct is a tag for overload resolution of std::pair's
+// constructor. Emplaces 100 -&gt; Foo(5, 10) in the map.
+int_to_foo.emplace(std::piecewise_construct,
+                   std::forward_as_tuple(100),
+                   std::forward_as_tuple(5, 10));
+</pre>
+
+## Conclusion
+
+Tag types are a powerful way to give additional information to the compiler.
+While at first glance they might seem magical, they use the same overload
+resolution and template type deduction rules as the rest of C++. The standard
+library uses class tags for disambiguating constructor calls, and you can use
+the same mechanisms to define tags for your own needs.
+
+## See Also
+
+-   [std::integer_sequence](https://en.cppreference.com/w/cpp/utility/integer_sequence)
+    for compile-time indexing of tuples
+-   [passkey for std::make_shared](/tips/134#what-about-stdshared-ptr) uses tags
+    to control access

--- a/docs/cpp/guides/abslstringify.md
+++ b/docs/cpp/guides/abslstringify.md
@@ -1,0 +1,150 @@
+---
+title: "AbslStringify"
+layout: docs
+sidenav: side-nav-cpp.html
+type: markdown
+---
+
+# AbslStringify
+
+Author: phoebeliang@
+
+The `AbslStringify()` extension point is a lightweight mechanism that allows
+users to format user-defined types as strings. User-defined types that provide
+an `AbslStringify()` definition are able to be formatted with libraries such as:
+
+*   [StrFormat](format)
+*   [Abseil Strings](strings) (including `absl::StrCat` and
+    `absl::Substitute`)
+*   [Abseil Logging](logging)
+*   [GoogleTest](https://github.com/google/googletest/blob/master/docs/index.md)
+
+Important: As with most type extensions, you should own the type you wish to
+extend.
+
+## Basic Usage
+
+Let's say that we have a simple `Point` struct:
+
+```cpp
+struct Point {
+  int x;
+  int y;
+};
+```
+
+If we want a `Point` to be formattable, we add a `friend` function template
+named `AbslStringify()`:
+
+```cpp
+struct Point {
+  template <typename Sink>
+  friend void AbslStringify(Sink& sink, const Point& p) {
+    absl::Format(&sink, "(%d, %d)", p.x, p.y);
+  }
+
+  int x;
+  int y;
+};
+```
+
+For enums, an `AbslStringify()` definition should be provided after the
+definition of the `enum`:
+
+```cpp
+namespace foo {
+
+enum class EnumWithStringify { kMany = 0, kChoices = 1 };
+
+template <typename Sink>
+void AbslStringify(Sink& sink, EnumWithStringify e) {
+  absl::Format(&sink, "%s", e == EnumWithStringify::kMany ? "Many" : "Choices");
+}
+
+}  // namespace foo
+```
+
+If you can't declare the function in the class it's important that
+`AbslStringify()` is defined in the **same** namespace that defines Point. C++'s
+look-up rules rely on that.
+
+Now these types will print correctly as defined with all the supported
+libraries.
+
+Examples using `Point`:
+
+```cpp
+// Strings and StrFormat
+absl::StrFormat("The point is %v", p);
+absl::StrCat("The point is ", p);
+absl::StrAppend(&str, p);
+absl::Substitute("The point is $0", p);
+
+// Logging
+LOG(INFO) << "The point is " << p;
+
+// GoogleTest
+EXPECT_EQ(p, expected); // error message prints type according to AbslStringify
+testing::PrintToString(p);
+```
+
+Important: When using `absl::StrFormat` for user-defined types, use the `%v`
+type specifier to format using `AbslStringify()`; using `%s` is not supported.
+See https://abseil.io/docs/cpp/guides/format for more details.
+
+Additionally, an implementation of `AbslStringify()` using `absl::Format` can
+use `%v` within the format string argument to perform type deduction. Our
+`Point` above could be formatted as `"(%v, %v)"` for example, which would give
+the same output as `"(%d, %d)"` in this case where we are formatting the `int`
+values `x` and `y`.
+
+Note: `CHECK_EQ(p, expected)` does not currently support `AbslStringify`-enabled
+types. `CHECK(p == expected) << p << "==" << expected` can be used for similar
+error-checking and logging capabilities.
+
+For more information about `AbslStringify`'s integration with any of these
+libraries, please refer to the documentation of the relevant library.
+
+### `AbslStringify`'s Sink
+
+`AbslStringify`'s underlying `Sink` supports `Append` operations, as well as
+`absl::Format`:
+
+```cpp
+// Append 3 copies of 'a'
+sink.Append(3, 'a')
+
+// Append "hello"
+sink.Append("hello")
+
+// Append "hello world"
+absl::Format(&sink, "hello %s", "world")
+```
+
+Warning: User-defined sinks are not supported.
+
+## Types with Built-In Support
+
+### Protocol Buffers
+
+Protocol buffer messages define `AbslStringify()` by default, so they can be
+formatted by all libraries that use this extension point. This is an overall
+smoother user experience over `DebugString()` as it produces less noisy code. It
+is recommended that users format protocol buffers directly rather than
+calling `DebugString()`.
+
+```proto
+message MyProto {
+  optional string my_string = 1
+}
+```
+
+```cpp
+MyProto my_proto;
+my_proto.set_my_string("hello world");
+
+absl::StrCat("My proto is: ", my_proto);
+absl::StrFormat("My proto is: %v", my_proto);
+LOG(INFO) << "My proto is: " << my_proto;
+EXPECT_THAT(my_proto, EqualsProto(expected_proto))
+```

--- a/docs/cpp/guides/container.md
+++ b/docs/cpp/guides/container.md
@@ -16,9 +16,9 @@ The Abseil containers are designed to be more efficient in the general case; in
 some cases, however, the STL containers may be more efficient. Unlike some other
 abstractions that Abseil provides, these containers should not be considered
 drop-in replacements for their STL counterparts, as there are API and/or
-contract differences between the two sets of containers. For example, the
-Abseil containers often do not guarantee pointer stability after insertions or
-deletions.
+contract differences between the two sets of containers. For example, the Abseil
+containers often do not guarantee pointer stability[^pointer-stability] after
+insertions or deletions.
 
 The Abseil `container` library defines the following sets of containers:
 
@@ -142,8 +142,7 @@ not keys) is needed, use `absl::flat_hash_map<Key, std::unique_ptr<Value>>`.
 These are near drop-in replacement for `std::unordered_map` and
 `std::unordered_set`. They are useful:
 
-*   When pointer stability[^pointer-stability] is required for both key and
-    value.
+*   When pointer stability is required for both key and value.
 *   For automatic migrations from `std::unordered_map`, `std::unordered_set`,
     `hash_map` or `hash_set` where it's difficult to figure out whether the code
     relies on pointer stability.

--- a/docs/cpp/guides/flags.md
+++ b/docs/cpp/guides/flags.md
@@ -260,6 +260,8 @@ named `FLAGS_name` of type `T`, use the `ABSL_DECLARE_FLAG(T, name);` macro
 defined in absl/flags/declare.h to do so:
 
 ```cpp
+#include "absl/flags/declare.h"
+
 ABSL_DECLARE_FLAG(absl::Duration, timeout);
 ```
 

--- a/docs/cpp/index.md
+++ b/docs/cpp/index.md
@@ -24,4 +24,4 @@ the header files directly.
 The following guides are general programming guides that we think are useful
 to C++ developers:
 
-* [The Danger of Atomic Operations](/docs/cpp/atomic_danger)
+* [The Danger of Atomic Operations](http://abseil.io/docs/cpp/atomicdanger)

--- a/docs/cpp/platforms/feature_checks.md
+++ b/docs/cpp/platforms/feature_checks.md
@@ -65,11 +65,13 @@ by explicitly listing all platforms where a given feature is available, or opt
 out by explicitly listing all platforms where a given feature is missing or
 broken. Either option has pros and cons:
 
-
-|      | opt-in                          | opt-out                             |
-| ---- | ------------------------------- | ----------------------------------- |
-| pros | Generally safe, and more likely to build on a new platform. | The compilation fails if a new platform doesn’t support the feature. |
-| cons | The allow-list needs to be extended for each new platform. | Compilation might succeed but runtime behavior might be unexpected, if the interface exists but the implementation is problematic. |
+* Pros:
+  * Generally safe, and more likely to build on a new platform.
+  * The compilation fails if a new platform doesn’t support the feature.
+* Cons:
+  * The allow-list needs to be extended for each new platform.
+  * Compilation might succeed but runtime behavior might be unexpected, if the
+    interface exists but the implementation is problematic.
 
 When choosing a opt-in or opt-out approach, think about what is likely to happen
 when a new platform is added and which approach is easier to maintain the


### PR DESCRIPTION
Included changes:

525540567(shreck):	Internal change
525521732(shreck):	Internal change
525518750(shreck):	Internal change
524818142(Abseil Team):	Fix typo to properly close the code block.
523832675(Abseil Team):	Internal change.
520976130(Abseil Team):	Add include statement to example code block for flag declarations
518887412(shreck):	Internal change
518039451(Abseil Team):	Revise documentation to include AbslStringify
518033221(Abseil Team):	Add a canonical document for `AbslStringify()