### PR TITLE
Update quickstart.md

### DIFF
--- a/docs/cpp/quickstart.md
+++ b/docs/cpp/quickstart.md
@@ -63,8 +63,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
   name = "com_google_absl",
-  urls = ["https://github.com/abseil/abseil-cpp/archive/98eb410c93ad059f9bba1bf43f5bb916fc92a5ea.zip"],
-  strip_prefix = "abseil-cpp-98eb410c93ad059f9bba1bf43f5bb916fc92a5ea",
+  urls = ["https://github.com/abseil/abseil-cpp/archive/4a2c63365eff8823a5221db86ef490e828306f9d.zip"],
+  strip_prefix = "abseil-cpp-4a2c63365eff8823a5221db86ef490e828306f9d",
 )
 ```
 


### PR DESCRIPTION
To reflect latest LTS branch - https://github.com/abseil/abseil-cpp/releases

This commit hash is missing the Abesil logging library, which was added in the Abseil LTS 20230125.3 release.