### PR TITLE
Specify unique_ptr lifetime

### DIFF
--- a/_posts/2017-12-07-totw-123.md
+++ b/_posts/2017-12-07-totw-123.md
@@ -181,7 +181,7 @@ that works. Prefer bare object, if it works for your case. Otherwise, try
     <td>Object lifetime</td>
     <td>Same as enclosing scope</td>
     <td>Restricted to enclosing scope</td>
-    <td>Unrestricted</td>
+    <td>Unrestricted if moved out of enclosing scope</td>
   </tr>
   <tr>
     <td markdown="span">Call `f(Bar*)`</td>


### PR DESCRIPTION
In @marcdiepold's opinion, the wording should be more specific here. If you don't move anything, the `std::unique_ptr` and its contents will vanish when the enclosing scope ends. We argue that this is the case for the vast majority of `std::unique_ptr` data members, thus the unrestricted lifetime should be further specified here.