### PR TITLE
Export of internal doc changes to C++ Tips:

### DIFF
--- a/_posts/2017-09-26-totw-1.md
+++ b/_posts/2017-09-26-totw-1.md
@@ -90,9 +90,19 @@ void AlreadyHasCharStar(const char* s) {
 
 Because the `string_view` does not own its data, any strings pointed to by the
 `string_view` (just like a `const char*`) must have a known lifespan, and must
-outlast the `string_view` itself. This means that using `string_view` for
-storage is often questionable: you need some proof that the underlying data will
-outlive the `string_view`.
+outlast the `string_view` itself.
+
+This means that using `string_view` for storage is often questionable: you need
+some proof that the underlying data will outlive the `string_view`. For example,
+the following struct probably doesn't make sense if it might be stored beyond
+the result of a function call that accepts it as a parameter:
+
+<pre class="prettyprint lang-cpp bad-code">
+struct TestScore {
+  absl::string_view username;  // Probably should be a `std::string`
+  double score;
+};
+</pre>
 
 If your API only needs to reference the string data during a single call, and
 doesn't need to modify the data, accepting a `string_view` is sufficient.

--- a/_posts/2020-04-06-totw-173.md
+++ b/_posts/2020-04-06-totw-173.md
@@ -77,7 +77,7 @@ PrintDouble(5.0, "my_value=", ',', '.', 2, false);
 </pre>
 
 Historically, we have used
-[argument comments](http://clang.llvm.org/extra/clang-tidy/checks/bugprone-argument-comment.html)
+[argument comments](http://clang.llvm.org/extra/clang-tidy/checks/bugprone/argument-comment.html)
 to clarify argument meanings at call sites to reduce this sort of ambiguity. The
 addition of argument comments to the above example would allow ClangTidy to
 detect the error:

--- a/_posts/2020-09-01-totw-140.md
+++ b/_posts/2020-09-01-totw-140.md
@@ -175,7 +175,8 @@ with a class. These always have external linkage.
 class Foo {
  public:
   static constexpr int kMyNumber = 42;
-  static constexpr char kMyHello[] = "Hello";
+  static constexpr absl::string_view kMyHello1 = "Hello";
+  static constexpr char kMyHello2[] = "Hello";  // No longer recommended
 };
 </pre>
 
@@ -186,7 +187,8 @@ data members in a `.cc` file, but for data members that are both `static` and
 <pre class="prettyprint lang-cpp code">
 // Defined in foo.cc, prior to C++17.
 constexpr int Foo::kMyNumber;
-constexpr char Foo::kMyHello[];
+constexpr absl::string_view Foo::kMyHello1;
+constexpr char Foo::kMyHello2[];
 </pre>
 
 It isn't worth introducing a class just to act as a scope for a bunch of

--- a/_posts/2024-03-21-totw-229.md
+++ b/_posts/2024-03-21-totw-229.md
@@ -46,7 +46,7 @@ size_t Size(const T& t);
 // you can copy and paste to get you started!
 namespace internal_size {
 
-// Use go/ranked-overloads for dispatching.
+// Use [Tip #229](/tips/229) for dispatching.
 struct Rank0 {};
 struct Rank1 : Rank0 {};
 struct Rank2 : Rank1 {};


### PR DESCRIPTION
rpc://team/absl-team/Abseil-Docs

Included changes:

678931469(shreck):	Internal change

678395151(Abseil Team):	Internal change

676046348(Abseil Team):	Internal change

668940956(Abseil Team):	Internal change

665593943(Abseil Team):	Internal change

665591390(jdennett):	Internal change

663056542(jdennett):	Internal change

659577831(jdennett):	Internal change

PiperOrigin-RevId: 678931469
Change-Id: I1403ca7e180d4a29f90cf01f160dc8a29d293c07