### PR TITLE
Export of internal doc changes to Abseil OSS:

### DIFF
--- a/docs/cpp/guides/format.md
+++ b/docs/cpp/guides/format.md
@@ -190,8 +190,8 @@ absl::StrFormat("%lld", 100'000'000'000'000) -> "100000000000000"
 
 // Floating Point
 // Default precision of %f conversion is 6
-absl::StrFormat("%f", 1.6)       -> "1.600000" // Width includes decimal pt.
-absl::StrFormat("%05.2f", 1.6)   -> "01.60"
+absl::StrFormat("%f", 1.6)       -> "1.600000"
+absl::StrFormat("%05.2f", 1.6)   -> "01.60"    // Width includes decimal pt.
 absl::StrFormat("%.1f", 1.63232) -> "1.6"      // Rounding down
 absl::StrFormat("%.3f", 1.63451) -> "1.635"    // Rounding up
 absl::StrFormat("%*.*f", 5, 2, 1.63451) -> " 1.63"  // Same as "%5.2f"

--- a/docs/cpp/guides/logging.md
+++ b/docs/cpp/guides/logging.md
@@ -26,6 +26,16 @@ will show up in the logfiles.
 
 For more detailed information, see the header files.
 
+### Header Files for `LOG()` and `CHECK()`
+
+Import the logging and check macros with the following #includes. The path to
+`absl` may differ depending on its installation location within your system.
+
+```c++
+#include "absl/log/log.h"
+#include "absl/log/check.h"
+```
+
 ### `LOG()` Macro {#LOG}
 
 `LOG()` takes a severity level as an argument, which defines the granularity and
@@ -172,6 +182,16 @@ There are also two pseudo-levels:
     usually the best choice for errors occurring at startup (e.g. flag
     validation) where the control flow is uninteresting and unnecessary to
     diagnosis.
+*   [`DO_NOT_SUBMIT`](#severity-do-not-submit){#severity-do-not-submit} is an
+    alias for `ERROR`, and is the right level to use when you are using `LOG`
+    for what's often called
+    [`printf()` debugging](https://en.wikipedia.org/wiki/Debugging#printf_debugging).
+    The name is easy to spot in review and is caught by common (but not
+    on-by-default) presubmit
+    checks.
+    The contract is that **it must not be checked in**, so the Abseil team
+    reserves the right to delete it, change what it does, and/or scrub any
+    instances that do end up checked in, with or without notice.
 
 If you want to specify a severity level using a C++ expression, e.g. so that the
 level used varies at runtime, you can do that too:
@@ -189,8 +209,8 @@ macro takes a non-negative integer verbosity level as an argument - `INFO`
 severity is implied. Verbosity level values are arbitrary, however lower values
 correspond to more readily-visible messages. Non-zero verbosity levels are
 disabled by default, and disabled `VLOG()`s have a very small performance cost,
-so liberal use of `VLOG()` is acceptable in most parts of google3 without risk
-of serious performance degradation or unacceptable log spam.
+so liberal use of `VLOG()` is acceptable in most cases without risk of serious
+performance degradation or unacceptable log spam.
 
 ```c++
 Foo::Foo(int num_bars) {

--- a/docs/cpp/guides/status.md
+++ b/docs/cpp/guides/status.md
@@ -196,7 +196,7 @@ if (i.ok()) {
 
 An `absl::StatusOr<T*>` can be constructed from a null pointer like any other
 pointer value, and the result will be that `ok()` returns `true` and `value()`
-returns `nullptr`. Checking the value of pointer in an `absl::StatusOr<T>`
+returns `nullptr`. Checking the value of pointer in an `absl::StatusOr<T*>`
 generally requires a bit more care, to ensure both that a value is present and
 that value is not null:
 

--- a/docs/cpp/guides/time.md
+++ b/docs/cpp/guides/time.md
@@ -459,7 +459,7 @@ year, month, day, hour, minute, and second.
 * `minute()` returning an `int`
 * `second()` returning an `int`
 
-Recall that fields inferior to the type's aligment will be set to their minimum
+Recall that fields inferior to the type's alignment will be set to their minimum
 valid value.
 
 ```cpp

--- a/docs/cpp/platforms/macros.md
+++ b/docs/cpp/platforms/macros.md
@@ -46,20 +46,14 @@ Pre-defined Compiler Macros</a>.</p>
 | `_M_ARM64`        | ARM64            | Visual Studio          |             |
 | `__i386__`        | Intel x86        |                        |             |
 | `_M_IX86`         | Intel x86        | Visual Studio\*        |             |
-| `__ia64__`        | Intel Itanum     |                        |             |
-:                   : (IA-64)          :                        :             :
-| `_M_IA64`         | Intel Itanum     | Visual Studio          |             |
-:                   : (IA-64)          :                        :             :
-| `__ppc__` <br/>   | PowerPC          |                        |             |
-: `__PPC__` <br/>   :                  :                        :             :
-: `__ppc64__` <br/> :                  :                        :             :
-: `__PPC64__`       :                  :                        :             :
+| `__ia64__`        | Intel Itanium (IA-64) |                   |             |
+| `_M_IA64`         | Intel Itanium (IA-64) | Visual Studio     |             |
+| `__ppc__`<br/>`__PPC__`<br/>`__ppc64__`<br/>`__PPC64__`<br/>  | PowerPC | | |
 | `_M_PPC`          | PowerPC          | Visual Studio          |             |
-| `__myriad2__`     | Myriad2          | Myriad Development Kit |             |
-:                   :                  : (Intel Movidius)       :             :
+| `__myriad2__`     | Myriad2     | Myriad Development Kit (Intel Movidius) | |
 | `__mips__`        | MIPS             | GNU C                  |             |
 
-\* Only defined for 32-bits architectures.
+\* Only defined for 32-bit architectures.
 
 References:
 

--- a/docs/cpp/quickstart-cmake.md
+++ b/docs/cpp/quickstart-cmake.md
@@ -20,14 +20,14 @@ Running the Abseil code within this tutorial requires:
 *   A compatible platform (e.g. Windows, macOS, Linux, etc.). Most platforms are
     fully supported. Consult the [Platforms Guide](platforms/platforms) for more
     information.
-*   A compatible C++ compiler *supporting at least C++14*. Most major compilers
+*   A compatible C++ compiler *supporting at least C++17*. Most major compilers
     are supported.
 *   [Git](https://git-scm.com/) for interacting with the Abseil source code
     repository, which is contained on [GitHub](http://github.com). To install
     Git, consult the [Set Up Git](https://help.github.com/articles/set-up-git/)
     guide on GitHub.
 *   [CMake](https://cmake.org/) for building your project and Abseil. Abseil
-    supports CMake 3.5+.
+    supports CMake 3.16+.
 
 ## Getting the Abseil Code
 
@@ -51,14 +51,14 @@ Navigate into this directory and run all tests:
 ```
 $ cd abseil-cpp
 $ mkdir build && cd build
-$ cmake -DABSL_BUILD_TESTING=ON -DABSL_USE_GOOGLETEST_HEAD=ON -DCMAKE_CXX_STANDARD=14 ..
+$ cmake -DABSL_BUILD_TESTING=ON -DABSL_USE_GOOGLETEST_HEAD=ON -DCMAKE_CXX_STANDARD=17 ..
 ...
 -- Configuring done
 -- Generating done
 -- Build files have been written to: ${PWD}
 ```
 
-`CMAKE_CXX_STANDARD=14` instructs CMake to build using the C++14 standard, which
+`CMAKE_CXX_STANDARD=17` instructs CMake to build using the C++17 standard, which
 is our minimum language level of support.
 
 Now you can build the CMake target tests:
@@ -144,8 +144,8 @@ cmake_minimum_required(VERSION 3.16)
 
 project(my_project)
 
-# Abseil requires C++14
-set(CMAKE_CXX_STANDARD 14)
+# Abseil requires C++17
+set(CMAKE_CXX_STANDARD 17)
 
 # Process Abseil's CMake build system
 add_subdirectory(abseil-cpp)

--- a/docs/cpp/quickstart.md
+++ b/docs/cpp/quickstart.md
@@ -25,7 +25,7 @@ Running the Abseil code within this tutorial requires:
 *   A compatible platform (e.g. Windows, macOS, Linux, etc.). Most platforms are
     fully supported. Consult the [Platforms Guide](platforms/platforms) for more
     information.
-*   A compatible C++ compiler *supporting at least C++14*. Most major compilers
+*   A compatible C++ compiler *supporting at least C++17*. Most major compilers
     are supported.
 
 Although you are free to use your own build system, most of the documentation

--- a/docs/cpp/tools/cmake-installs.md
+++ b/docs/cpp/tools/cmake-installs.md
@@ -102,7 +102,7 @@ int main() {
 
 Our `CMakeLists.txt` for this local project needs to be slightly different than
 the one we used in the
-[CMake Quickstart](/docs/ccp/quickstart-cmake) -- we use
+[CMake Quickstart](/docs/cpp/quickstart-cmake) -- we use
 `find_package` to import Abseil's targets from our local `install` directory.
 
 ```


### PR DESCRIPTION
rpc://team/absl-team/Abseil-Docs

Included changes:

742757095(Abseil Team):	Add some clarifying notes to cpp/guides/random.md
738364247(Abseil Team):	Add a log severity alias `DO_NOT_$UBMIT` intended for logging during development'S' should be replace with S, in DO_NOT_$UBMIT :-)`DO_NOT_$UBMIT` is an alias for `ERROR`, and is the right level to usewhen you are using `LOG` for what's often called `printf()` debugging.The name is easy to spot in review and is caught by common (but noton-by-default) presubmit checks.The contract is that **it must not be checked in**, so the Abseil teamreserves the right to delete it, change what it does, and/or scrub anyinstances that do end up checked in, with or without notice.Git users could consider adding a pre-commit hook to rejectthe string "DO_NOT_$UBMIT" to use this feature.https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
729158223(Abseil Team):	Add missing semi-colon to mocking BitGen example
723589409(Abseil Team):	Require C++17Policy information:https://opensource.google/documentation/policies/cplusplus-support#c_language_standardhttps://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md
718890924(Abseil Team):	Update Abseil random guide; notes about seeding
716383008(Abseil Team):	Fix typo in Cmake quickstart link.
704470276(Abseil Team):	Specify the include file for logging in the documentation.This change makes it explicit which files need to be included to access the logging and check macros.
703601899(Abseil Team):	Update `absl::Hash` documentation to include information on `combine_unordered` and on the hashability of the Abseil hashed containers.
702746774(jdennett):	Minor documentation cleanup.
702029567(Abseil Team):	Comment fix.
700483316(Abseil Team):	Update documentation for hash-based containersThis CL updates absl::Hash-related documentation to highlight thatabsl::DefaultHashContainerHash/absl::DefaultHashContainerEq should beused when Hash/Eq type arguments are needed to be set explicitly.
697751077(Abseil Team):	Remove google3 from public documentation.
697728861(Abseil Team):	Update random guides with {.bad} and {.good}
697690960(jdennett):	Internal change
696991459(Abseil Team):	Fix table rendering for abseil.io/docs/cpp/platforms/macros
686511523(Abseil Team):	Fix typo in StatusOr documentation.
684569306(Abseil Team):	Fix a typo in the absl::Time documentation.
678256557(Abseil Team):	Replace documentation reference from gtl::pb_equiv with gtl::pb_equals (the former one is deprecated)
660440688(Abseil Team):	Internal change

PiperOrigin-RevId: 742757095
Change-Id: I0ef9138edc4e6eb1d2c23ea742a404239a0eea4e