### PR TITLE
Improve unordered list rendering.

### DIFF
--- a/_sass/base/_markdown.scss
+++ b/_sass/base/_markdown.scss
@@ -32,7 +32,6 @@
   ol,
   ul {
     list-style: initial;
-    list-style-position: inside;
     font-size: 15px;
     font-weight: 300;
     margin: 0 20px;


### PR DESCRIPTION
There are a number of situations where "list-style-position: inside;" actually makes the rendering more awkward, and I do not see any benefits where I personally find that the existing behavior is better than the alternative.

The main concrete examples I noticed when digging into this initially:

https://stevewang.github.io/abseil.github.io/docs/cpp/platforms/compilerflags#clang-flags
https://abseil.io/docs/cpp/platforms/compilerflags#clang-flags

I don't see this as being obviously better / worse, but I personally prefer the former appearance (proposed new behavior), where the bullet point is out-of-line, and the text of the paragraphs are aligned (as opposed to aligning with the bullet point)

https://stevewang.github.io/abseil.github.io/tips/234#pass-by-value
https://abseil.io/tips/234#pass-by-value

This was the original motivation for this change. If there are multiple paragraphs in an unordered list, the existing style forces the first paragraph to render on a separate line entirely, leaving an ugly gap.

Note that I've also fixed the formatting of the footnotes at the bottom of TotW 234 because it bothered me. I fixed that internally a while ago, but it hasn't been exported to github yet.

Also, note that not all of the links on stevewang.github.io/abseil.github.io work, since {{ site.baseurl }} isn't consistently set across the board. I've attempted fixing it in most instances, but not all. (My site is built from https://github.com/steveWang/abseil.github.io/tree/relative-paths which I do not recommend upstreaming in its current capacity.)